### PR TITLE
Added Bengali spacing and punctuations

### DIFF
--- a/app/src/main/res/values-bn/donottranslate-config-spacing-and-punctuations.xml
+++ b/app/src/main/res/values-bn/donottranslate-config-spacing-and-punctuations.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2013, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Same list as in English, but added Devanagari Danda and Double Danda: -->
+    <!-- U+0964: "।" DEVANAGARI DANDA  -->
+    <!-- U+0965: "॥" DEVANAGARI DOUBLE DANDA -->
+    <!-- Symbols that are normally followed by a space (used to add an auto-space after these) -->
+    <string name="symbols_followed_by_space">.,;:!?)]}&amp;&#x0964;&#x0965;</string>
+    <!-- Symbols that separate words. Added Devanagari Danda and Double Danda. -->
+    <!-- Don't remove the enclosing double quotes, they protect whitespace (not just U+0020) -->
+    <string name="symbols_word_separators">"&#x0009;&#x0020;&#x000A;&#x00A0;"()[]{}*&amp;&lt;&gt;+=|.,;:!?/_\"&#x0964;&#x0965;</string>
+    <!-- The sentence separator code point, for capitalization and auto-insertion -->
+    <!-- U+0964: "।" DEVANAGARI DANDA  -->
+    <integer name="sentence_separator">2404</integer>
+    <!-- Symbols that terminate sentences and require capitalization on the next char -->
+    <string name="symbols_sentence_terminators">.?!।॥</string>
+</resources>


### PR DESCRIPTION
Enables the ability to add an auto-space after the Bengali Dari (DEVANAGARI DANDA) & Double Dari (DEVANAGARI DOUBLE DANDA). Added Devanagari Danda and Double Danda as word and sentence separators. 

This resolves bug #477