### PR TITLE
Extended number row support for every keyboards

### DIFF
--- a/app/src/main/res/xml-sw600dp-land/rows_german.xml
+++ b/app/src/main/res/xml-sw600dp-land/rows_german.xml
@@ -26,18 +26,8 @@
     <!-- TODO: Consolidate the layout specification between protrait and landscape.
          Ideally just the keyWidth should be different and the spacer should adjust to fill
          the available space. -->
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <!-- First row -->
     <Row
         latin:keyWidth="8.182%p"

--- a/app/src/main/res/xml-sw600dp-land/rows_german.xml
+++ b/app/src/main/res/xml-sw600dp-land/rows_german.xml
@@ -26,6 +26,18 @@
     <!-- TODO: Consolidate the layout specification between protrait and landscape.
          Ideally just the keyWidth should be different and the spacer should adjust to fill
          the available space. -->
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <!-- First row -->
     <Row
         latin:keyWidth="8.182%p"

--- a/app/src/main/res/xml-sw600dp-land/rows_qwerty.xml
+++ b/app/src/main/res/xml-sw600dp-land/rows_qwerty.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <!-- First row -->
     <Row>
         <switch>

--- a/app/src/main/res/xml-sw600dp-land/rows_qwertz.xml
+++ b/app/src/main/res/xml-sw600dp-land/rows_qwertz.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <!-- First row -->
     <Row>
         <switch>

--- a/app/src/main/res/xml-sw600dp/rows_arabic.xml
+++ b/app/src/main/res/xml-sw600dp/rows_arabic.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml-sw600dp/rows_arabic.xml
+++ b/app/src/main/res/xml-sw600dp/rows_arabic.xml
@@ -20,6 +20,18 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml-sw600dp/rows_arabic_pc.xml
+++ b/app/src/main/res/xml-sw600dp/rows_arabic_pc.xml
@@ -20,6 +20,18 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="9%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml-sw600dp/rows_arabic_pc.xml
+++ b/app/src/main/res/xml-sw600dp/rows_arabic_pc.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml-sw600dp/rows_armenian_phonetic.xml
+++ b/app/src/main/res/xml-sw600dp/rows_armenian_phonetic.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.0%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml-sw600dp/rows_armenian_phonetic.xml
+++ b/app/src/main/res/xml-sw600dp/rows_armenian_phonetic.xml
@@ -20,6 +20,18 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="9.0%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml-sw600dp/rows_azerty.xml
+++ b/app/src/main/res/xml-sw600dp/rows_azerty.xml
@@ -25,18 +25,8 @@
         latin:keyboardLayout="@xml/key_styles_common" />
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.0%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_bengali.xml
+++ b/app/src/main/res/xml-sw600dp/rows_bengali.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml-sw600dp/rows_bengali.xml
+++ b/app/src/main/res/xml-sw600dp/rows_bengali.xml
@@ -20,6 +20,18 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml-sw600dp/rows_bengali_akkhor.xml
+++ b/app/src/main/res/xml-sw600dp/rows_bengali_akkhor.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto" >
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyLabelFlags="fontNormal"
         latin:keyWidth="8.182%p" >

--- a/app/src/main/res/xml-sw600dp/rows_bengali_akkhor.xml
+++ b/app/src/main/res/xml-sw600dp/rows_bengali_akkhor.xml
@@ -20,6 +20,18 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto" >
     <include latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyLabelFlags="fontNormal"
         latin:keyWidth="8.182%p" >

--- a/app/src/main/res/xml-sw600dp/rows_bengali_unijoy.xml
+++ b/app/src/main/res/xml-sw600dp/rows_bengali_unijoy.xml
@@ -19,20 +19,44 @@
 -->
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
-    <include latin:keyboardLayout="@xml/key_styles_common" />
-    <Row latin:keyLabelFlags="fontNormal" latin:keyWidth="9.0%p">
-        <include latin:keyboardLayout="@xml/rowkeys_bengali_unijoy1" />
-        <Key latin:keyStyle="deleteKeyStyle" latin:keyWidth="fillRight" />
+    <include latin:keyboardLayout="@xml/key_styles_common"/>
+    <switch>
+        <case latin:numberRowEnabled="true">
+            <Row latin:keyWidth="10%p">
+                <include latin:keyboardLayout="@xml/rowkeys_symbols1"/>
+            </Row>
+        </case>
+    </switch>
+    <Row
+        latin:keyLabelFlags="fontNormal"
+        latin:keyWidth="9.0%p">
+        <include latin:keyboardLayout="@xml/rowkeys_bengali_unijoy1"/>
+        <Key
+            latin:keyStyle="deleteKeyStyle"
+            latin:keyWidth="fillRight"/>
     </Row>
     <Row latin:keyLabelFlags="fontNormal">
-        <include latin:keyboardLayout="@xml/rowkeys_bengali_unijoy2" latin:keyXPos="4.5%p" latin:keyWidth="9.0%p" />
-        <Key latin:keyStyle="enterKeyStyle" latin:keyWidth="fillRight" />
+        <include
+            latin:keyboardLayout="@xml/rowkeys_bengali_unijoy2"
+            latin:keyXPos="4.5%p"
+            latin:keyWidth="9.0%p"/>
+        <Key
+            latin:keyStyle="enterKeyStyle"
+            latin:keyWidth="fillRight"/>
     </Row>
     <Row latin:keyLabelFlags="fontNormal">
-        <Key latin:keyStyle="shiftKeyStyle" latin:keyWidth="10.0%p" />
-        <include latin:keyboardLayout="@xml/rowkeys_bengali_unijoy3" latin:keyWidth="9.0%p" />
-        <include latin:keyboardLayout="@xml/keys_exclamation_question" latin:keyWidth="9.0%p" />
-        <Key latin:keyStyle="shiftKeyStyle" latin:keyWidth="fillRight" />
+        <Key
+            latin:keyStyle="shiftKeyStyle"
+            latin:keyWidth="10.0%p"/>
+        <include
+            latin:keyboardLayout="@xml/rowkeys_bengali_unijoy3"
+            latin:keyWidth="9.0%p"/>
+        <include
+            latin:keyboardLayout="@xml/keys_exclamation_question"
+            latin:keyWidth="9.0%p"/>
+        <Key
+            latin:keyStyle="shiftKeyStyle"
+            latin:keyWidth="fillRight"/>
     </Row>
-    <include latin:keyboardLayout="@xml/row_qwerty4" />
+    <include latin:keyboardLayout="@xml/row_qwerty4"/>
 </merge>

--- a/app/src/main/res/xml-sw600dp/rows_bengali_unijoy.xml
+++ b/app/src/main/res/xml-sw600dp/rows_bengali_unijoy.xml
@@ -20,13 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common"/>
-    <switch>
-        <case latin:numberRowEnabled="true">
-            <Row latin:keyWidth="10%p">
-                <include latin:keyboardLayout="@xml/rowkeys_symbols1"/>
-            </Row>
-        </case>
-    </switch>
+    <include latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyLabelFlags="fontNormal"
         latin:keyWidth="9.0%p">

--- a/app/src/main/res/xml-sw600dp/rows_bepo.xml
+++ b/app/src/main/res/xml-sw600dp/rows_bepo.xml
@@ -18,18 +18,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.0%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_bulgarian.xml
+++ b/app/src/main/res/xml-sw600dp/rows_bulgarian.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.182%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_bulgarian.xml
+++ b/app/src/main/res/xml-sw600dp/rows_bulgarian.xml
@@ -23,6 +23,18 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="8.182%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_bulgarian_bds.xml
+++ b/app/src/main/res/xml-sw600dp/rows_bulgarian_bds.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.182%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_bulgarian_bds.xml
+++ b/app/src/main/res/xml-sw600dp/rows_bulgarian_bds.xml
@@ -23,6 +23,18 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="8.182%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_bulgarian_bekl.xml
+++ b/app/src/main/res/xml-sw600dp/rows_bulgarian_bekl.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.182%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_bulgarian_bekl.xml
+++ b/app/src/main/res/xml-sw600dp/rows_bulgarian_bekl.xml
@@ -23,6 +23,18 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="8.182%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_colemak.xml
+++ b/app/src/main/res/xml-sw600dp/rows_colemak.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.0%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_colemak_dh.xml
+++ b/app/src/main/res/xml-sw600dp/rows_colemak_dh.xml
@@ -23,18 +23,8 @@
     >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.0%p"
         >

--- a/app/src/main/res/xml-sw600dp/rows_dvorak.xml
+++ b/app/src/main/res/xml-sw600dp/rows_dvorak.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.0%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_east_slavic.xml
+++ b/app/src/main/res/xml-sw600dp/rows_east_slavic.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.182%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_east_slavic.xml
+++ b/app/src/main/res/xml-sw600dp/rows_east_slavic.xml
@@ -23,6 +23,18 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="8.182%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_farsi.xml
+++ b/app/src/main/res/xml-sw600dp/rows_farsi.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml-sw600dp/rows_farsi.xml
+++ b/app/src/main/res/xml-sw600dp/rows_farsi.xml
@@ -20,6 +20,18 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml-sw600dp/rows_georgian.xml
+++ b/app/src/main/res/xml-sw600dp/rows_georgian.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.0%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_georgian.xml
+++ b/app/src/main/res/xml-sw600dp/rows_georgian.xml
@@ -23,6 +23,18 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="9.0%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_german.xml
+++ b/app/src/main/res/xml-sw600dp/rows_german.xml
@@ -26,18 +26,8 @@
     <!-- TODO: Consolidate the layout specification between protrait and landscape.
          Ideally just the keyWidth should be different and the spacer should adjust to fill
          the available space. -->
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <!-- First row -->
     <Row
         latin:keyWidth="8.182%p"

--- a/app/src/main/res/xml-sw600dp/rows_german.xml
+++ b/app/src/main/res/xml-sw600dp/rows_german.xml
@@ -26,6 +26,18 @@
     <!-- TODO: Consolidate the layout specification between protrait and landscape.
          Ideally just the keyWidth should be different and the spacer should adjust to fill
          the available space. -->
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <!-- First row -->
     <Row
         latin:keyWidth="8.182%p"

--- a/app/src/main/res/xml-sw600dp/rows_greek.xml
+++ b/app/src/main/res/xml-sw600dp/rows_greek.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.0%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_greek.xml
+++ b/app/src/main/res/xml-sw600dp/rows_greek.xml
@@ -23,6 +23,18 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="9.0%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_hebrew.xml
+++ b/app/src/main/res/xml-sw600dp/rows_hebrew.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.0%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_hebrew.xml
+++ b/app/src/main/res/xml-sw600dp/rows_hebrew.xml
@@ -23,6 +23,18 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="9.0%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_hindi.xml
+++ b/app/src/main/res/xml-sw600dp/rows_hindi.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml-sw600dp/rows_hindi.xml
+++ b/app/src/main/res/xml-sw600dp/rows_hindi.xml
@@ -20,6 +20,18 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml-sw600dp/rows_hindi_compact.xml
+++ b/app/src/main/res/xml-sw600dp/rows_hindi_compact.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml-sw600dp/rows_hindi_compact.xml
+++ b/app/src/main/res/xml-sw600dp/rows_hindi_compact.xml
@@ -20,6 +20,18 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml-sw600dp/rows_kannada.xml
+++ b/app/src/main/res/xml-sw600dp/rows_kannada.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal|autoXScale"

--- a/app/src/main/res/xml-sw600dp/rows_kannada.xml
+++ b/app/src/main/res/xml-sw600dp/rows_kannada.xml
@@ -20,6 +20,18 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal|autoXScale"

--- a/app/src/main/res/xml-sw600dp/rows_khmer.xml
+++ b/app/src/main/res/xml-sw600dp/rows_khmer.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="7.5%p"
         latin:keyLabelFlags="fontNormal|autoXScale"

--- a/app/src/main/res/xml-sw600dp/rows_khmer.xml
+++ b/app/src/main/res/xml-sw600dp/rows_khmer.xml
@@ -20,6 +20,18 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="7.5%p"
         latin:keyLabelFlags="fontNormal|autoXScale"

--- a/app/src/main/res/xml-sw600dp/rows_lao.xml
+++ b/app/src/main/res/xml-sw600dp/rows_lao.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="7.5%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml-sw600dp/rows_lao.xml
+++ b/app/src/main/res/xml-sw600dp/rows_lao.xml
@@ -20,6 +20,18 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="7.5%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml-sw600dp/rows_malayalam.xml
+++ b/app/src/main/res/xml-sw600dp/rows_malayalam.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal|autoXScale"

--- a/app/src/main/res/xml-sw600dp/rows_malayalam.xml
+++ b/app/src/main/res/xml-sw600dp/rows_malayalam.xml
@@ -20,6 +20,18 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal|autoXScale"

--- a/app/src/main/res/xml-sw600dp/rows_marathi.xml
+++ b/app/src/main/res/xml-sw600dp/rows_marathi.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml-sw600dp/rows_marathi.xml
+++ b/app/src/main/res/xml-sw600dp/rows_marathi.xml
@@ -20,6 +20,18 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml-sw600dp/rows_mongolian.xml
+++ b/app/src/main/res/xml-sw600dp/rows_mongolian.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.182%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_mongolian.xml
+++ b/app/src/main/res/xml-sw600dp/rows_mongolian.xml
@@ -23,6 +23,18 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="8.182%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_nepali_romanized.xml
+++ b/app/src/main/res/xml-sw600dp/rows_nepali_romanized.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml-sw600dp/rows_nepali_romanized.xml
+++ b/app/src/main/res/xml-sw600dp/rows_nepali_romanized.xml
@@ -20,6 +20,18 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml-sw600dp/rows_nepali_traditional.xml
+++ b/app/src/main/res/xml-sw600dp/rows_nepali_traditional.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml-sw600dp/rows_nepali_traditional.xml
+++ b/app/src/main/res/xml-sw600dp/rows_nepali_traditional.xml
@@ -20,6 +20,18 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml-sw600dp/rows_nordic.xml
+++ b/app/src/main/res/xml-sw600dp/rows_nordic.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.182%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_nordic.xml
+++ b/app/src/main/res/xml-sw600dp/rows_nordic.xml
@@ -23,6 +23,18 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="8.182%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_pcqwerty.xml
+++ b/app/src/main/res/xml-sw600dp/rows_pcqwerty.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="7.0%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_qwerty.xml
+++ b/app/src/main/res/xml-sw600dp/rows_qwerty.xml
@@ -26,18 +26,8 @@
     <!-- TODO: Consolidate the layout specification between protrait and landscape.
          Ideally just the keyWidth should be different and the spacer should adjust to fill
          the available space. -->
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <!-- First row -->
     <Row>
         <switch>

--- a/app/src/main/res/xml-sw600dp/rows_qwertz.xml
+++ b/app/src/main/res/xml-sw600dp/rows_qwertz.xml
@@ -26,18 +26,8 @@
     <!-- TODO: Consolidate the layout specification between protrait and landscape.
          Ideally just the keyWidth should be different and the spacer should adjust to fill
          the available space. -->
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <!-- First row -->
     <Row>
         <switch>

--- a/app/src/main/res/xml-sw600dp/rows_sinhala.xml
+++ b/app/src/main/res/xml-sw600dp/rows_sinhala.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal|autoXScale"

--- a/app/src/main/res/xml-sw600dp/rows_sinhala.xml
+++ b/app/src/main/res/xml-sw600dp/rows_sinhala.xml
@@ -20,6 +20,18 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal|autoXScale"

--- a/app/src/main/res/xml-sw600dp/rows_south_slavic.xml
+++ b/app/src/main/res/xml-sw600dp/rows_south_slavic.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.182%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_south_slavic.xml
+++ b/app/src/main/res/xml-sw600dp/rows_south_slavic.xml
@@ -23,6 +23,18 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="8.182%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_spanish.xml
+++ b/app/src/main/res/xml-sw600dp/rows_spanish.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.0%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_spanish.xml
+++ b/app/src/main/res/xml-sw600dp/rows_spanish.xml
@@ -23,6 +23,18 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="9.0%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_swiss.xml
+++ b/app/src/main/res/xml-sw600dp/rows_swiss.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.182%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_swiss.xml
+++ b/app/src/main/res/xml-sw600dp/rows_swiss.xml
@@ -23,6 +23,18 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="8.182%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_symbols.xml
+++ b/app/src/main/res/xml-sw600dp/rows_symbols.xml
@@ -25,15 +25,38 @@
         latin:keyboardLayout="@xml/key_styles_common" />
     <include
         latin:keyboardLayout="@xml/key_styles_currency" />
-    <Row
-        latin:keyWidth="9.0%p"
-    >
-        <include
-            latin:keyboardLayout="@xml/rowkeys_symbols1" />
-        <Key
-            latin:keyStyle="deleteKeyStyle"
-            latin:keyWidth="fillRight" />
-    </Row>
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+            <Row
+                latin:keyWidth="9.0%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols_shift1" />
+                <Key
+                    latin:keyStyle="deleteKeyStyle"
+                    latin:keyWidth="fillRight" />
+            </Row>
+        </case>
+        <default>
+            <Row
+                latin:keyWidth="9.0%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+                <Key
+                    latin:keyStyle="deleteKeyStyle"
+                    latin:keyWidth="fillRight" />
+            </Row>
+        </default>
+    </switch>
     <Row
         latin:keyWidth="9.0%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_symbols_shift.xml
+++ b/app/src/main/res/xml-sw600dp/rows_symbols_shift.xml
@@ -25,6 +25,18 @@
         latin:keyboardLayout="@xml/key_styles_common" />
     <include
         latin:keyboardLayout="@xml/key_styles_currency" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="9.0%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_symbols_shift.xml
+++ b/app/src/main/res/xml-sw600dp/rows_symbols_shift.xml
@@ -25,18 +25,8 @@
         latin:keyboardLayout="@xml/key_styles_common" />
     <include
         latin:keyboardLayout="@xml/key_styles_currency" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.0%p"
     >

--- a/app/src/main/res/xml-sw600dp/rows_tamil.xml
+++ b/app/src/main/res/xml-sw600dp/rows_tamil.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal|autoXScale"

--- a/app/src/main/res/xml-sw600dp/rows_tamil.xml
+++ b/app/src/main/res/xml-sw600dp/rows_tamil.xml
@@ -20,6 +20,18 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal|autoXScale"

--- a/app/src/main/res/xml-sw600dp/rows_telugu.xml
+++ b/app/src/main/res/xml-sw600dp/rows_telugu.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal|autoXScale"

--- a/app/src/main/res/xml-sw600dp/rows_telugu.xml
+++ b/app/src/main/res/xml-sw600dp/rows_telugu.xml
@@ -20,6 +20,18 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal|autoXScale"

--- a/app/src/main/res/xml-sw600dp/rows_thai.xml
+++ b/app/src/main/res/xml-sw600dp/rows_thai.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="7.5%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml-sw600dp/rows_thai.xml
+++ b/app/src/main/res/xml-sw600dp/rows_thai.xml
@@ -20,6 +20,18 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row
         latin:keyWidth="7.5%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml-sw600dp/rows_uzbek.xml
+++ b/app/src/main/res/xml-sw600dp/rows_uzbek.xml
@@ -20,6 +20,18 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto" >
     <include latin:keyboardLayout="@xml/key_styles_common" />
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <Row latin:keyWidth="8.182%p" >
         <include latin:keyboardLayout="@xml/rowkeys_uzbek1" />
         <Key

--- a/app/src/main/res/xml-sw600dp/rows_uzbek.xml
+++ b/app/src/main/res/xml-sw600dp/rows_uzbek.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto" >
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row latin:keyWidth="8.182%p" >
         <include latin:keyboardLayout="@xml/rowkeys_uzbek1" />
         <Key

--- a/app/src/main/res/xml-sw600dp/rows_workman.xml
+++ b/app/src/main/res/xml-sw600dp/rows_workman.xml
@@ -25,6 +25,18 @@
         latin:keyboardLayout="@xml/key_styles_common" />
          Ideally just the keyWidth should be different and the spacer should adjust to fill
          the available space. -->
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
     <!-- First row -->
     <Row>
         <include

--- a/app/src/main/res/xml-sw600dp/rows_workman.xml
+++ b/app/src/main/res/xml-sw600dp/rows_workman.xml
@@ -25,18 +25,8 @@
         latin:keyboardLayout="@xml/key_styles_common" />
          Ideally just the keyWidth should be different and the spacer should adjust to fill
          the available space. -->
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <!-- First row -->
     <Row>
         <include

--- a/app/src/main/res/xml/row_optional_number_row.xml
+++ b/app/src/main/res/xml/row_optional_number_row.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto">
+    <switch>
+        <case
+            latin:numberRowEnabled="true"
+            >
+            <Row
+                latin:keyWidth="10%p"
+                >
+                <include
+                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
+            </Row>
+        </case>
+    </switch>
+</merge>

--- a/app/src/main/res/xml/rows_arabic.xml
+++ b/app/src/main/res/xml/rows_arabic.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.091%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml/rows_arabic_pc.xml
+++ b/app/src/main/res/xml/rows_arabic_pc.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="10%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml/rows_armenian_phonetic.xml
+++ b/app/src/main/res/xml/rows_armenian_phonetic.xml
@@ -21,18 +21,8 @@
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
     <include latin:keyboardLayout="@xml/key_styles_currency" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="10.0%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml/rows_azerty.xml
+++ b/app/src/main/res/xml/rows_azerty.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="10%p"
     >

--- a/app/src/main/res/xml/rows_bengali.xml
+++ b/app/src/main/res/xml/rows_bengali.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.091%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml/rows_bengali_akkhor.xml
+++ b/app/src/main/res/xml/rows_bengali_akkhor.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto" >
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyLabelFlags="fontNormal"
         latin:keyWidth="9.091%p" >

--- a/app/src/main/res/xml/rows_bengali_unijoy.xml
+++ b/app/src/main/res/xml/rows_bengali_unijoy.xml
@@ -19,24 +19,38 @@
 -->
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
-    <include latin:keyboardLayout="@xml/key_styles_common" />
+    <include latin:keyboardLayout="@xml/key_styles_common"/>
     <switch>
         <case latin:numberRowEnabled="true">
             <Row latin:keyWidth="10%p">
-                <include latin:keyboardLayout="@xml/rowkeys_symbols1" />
+                <include latin:keyboardLayout="@xml/rowkeys_symbols1"/>
             </Row>
         </case>
     </switch>
-    <Row latin:keyLabelFlags="fontNormal" latin:keyWidth="10%p">
-        <include latin:keyboardLayout="@xml/rowkeys_bengali_unijoy1" />
+    <Row
+        latin:keyLabelFlags="fontNormal"
+        latin:keyWidth="10%p">
+        <include latin:keyboardLayout="@xml/rowkeys_bengali_unijoy1"/>
     </Row>
-    <Row latin:keyLabelFlags="fontNormal" latin:keyWidth="10%p">
-        <include latin:keyboardLayout="@xml/rowkeys_bengali_unijoy2" latin:keyXPos="5%p" />
+    <Row
+        latin:keyLabelFlags="fontNormal"
+        latin:keyWidth="10%p">
+        <include
+            latin:keyboardLayout="@xml/rowkeys_bengali_unijoy2"
+            latin:keyXPos="5%p"/>
     </Row>
-    <Row latin:keyLabelFlags="fontNormal" latin:keyWidth="10%p">
-        <Key latin:keyStyle="shiftKeyStyle" latin:keyWidth="15%p" latin:visualInsetsRight="1%p" />
-        <include latin:keyboardLayout="@xml/rowkeys_bengali_unijoy3" />
-        <Key latin:keyStyle="deleteKeyStyle" latin:keyWidth="fillRight" latin:visualInsetsLeft="1%p" />
+    <Row
+        latin:keyLabelFlags="fontNormal"
+        latin:keyWidth="10%p">
+        <Key
+            latin:keyStyle="shiftKeyStyle"
+            latin:keyWidth="15%p"
+            latin:visualInsetsRight="1%p"/>
+        <include latin:keyboardLayout="@xml/rowkeys_bengali_unijoy3"/>
+        <Key
+            latin:keyStyle="deleteKeyStyle"
+            latin:keyWidth="fillRight"
+            latin:visualInsetsLeft="1%p"/>
     </Row>
-    <include latin:keyboardLayout="@xml/row_qwerty4" />
+    <include latin:keyboardLayout="@xml/row_qwerty4"/>
 </merge>

--- a/app/src/main/res/xml/rows_bengali_unijoy.xml
+++ b/app/src/main/res/xml/rows_bengali_unijoy.xml
@@ -20,13 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common"/>
-    <switch>
-        <case latin:numberRowEnabled="true">
-            <Row latin:keyWidth="10%p">
-                <include latin:keyboardLayout="@xml/rowkeys_symbols1"/>
-            </Row>
-        </case>
-    </switch>
+    <include latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyLabelFlags="fontNormal"
         latin:keyWidth="10%p">

--- a/app/src/main/res/xml/rows_bepo.xml
+++ b/app/src/main/res/xml/rows_bepo.xml
@@ -18,18 +18,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="10%p"
     >

--- a/app/src/main/res/xml/rows_bulgarian.xml
+++ b/app/src/main/res/xml/rows_bulgarian.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.091%p"
     >

--- a/app/src/main/res/xml/rows_bulgarian_bds.xml
+++ b/app/src/main/res/xml/rows_bulgarian_bds.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.091%p"
     >

--- a/app/src/main/res/xml/rows_bulgarian_bekl.xml
+++ b/app/src/main/res/xml/rows_bulgarian_bekl.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.091%p"
     >

--- a/app/src/main/res/xml/rows_colemak.xml
+++ b/app/src/main/res/xml/rows_colemak.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="10%p"
     >

--- a/app/src/main/res/xml/rows_colemak_dh.xml
+++ b/app/src/main/res/xml/rows_colemak_dh.xml
@@ -23,18 +23,8 @@
     >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="10%p"
         >

--- a/app/src/main/res/xml/rows_dvorak.xml
+++ b/app/src/main/res/xml/rows_dvorak.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="10%p"
     >

--- a/app/src/main/res/xml/rows_east_slavic.xml
+++ b/app/src/main/res/xml/rows_east_slavic.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.091%p"
     >

--- a/app/src/main/res/xml/rows_farsi.xml
+++ b/app/src/main/res/xml/rows_farsi.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.091%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml/rows_georgian.xml
+++ b/app/src/main/res/xml/rows_georgian.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="10%p"
     >

--- a/app/src/main/res/xml/rows_german.xml
+++ b/app/src/main/res/xml/rows_german.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.091%p"
     >

--- a/app/src/main/res/xml/rows_greek.xml
+++ b/app/src/main/res/xml/rows_greek.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="10%p"
     >

--- a/app/src/main/res/xml/rows_hebrew.xml
+++ b/app/src/main/res/xml/rows_hebrew.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="10%p"
     >

--- a/app/src/main/res/xml/rows_hindi.xml
+++ b/app/src/main/res/xml/rows_hindi.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.091%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml/rows_hindi_compact.xml
+++ b/app/src/main/res/xml/rows_hindi_compact.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.091%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml/rows_kannada.xml
+++ b/app/src/main/res/xml/rows_kannada.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.091%p"
         latin:keyLabelFlags="fontNormal|autoXScale"

--- a/app/src/main/res/xml/rows_khmer.xml
+++ b/app/src/main/res/xml/rows_khmer.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.3333%p"
         latin:keyLabelFlags="fontNormal|autoXScale"

--- a/app/src/main/res/xml/rows_lao.xml
+++ b/app/src/main/res/xml/rows_lao.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.3333%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml/rows_malayalam.xml
+++ b/app/src/main/res/xml/rows_malayalam.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.091%p"
         latin:keyLabelFlags="fontNormal|autoXScale"

--- a/app/src/main/res/xml/rows_marathi.xml
+++ b/app/src/main/res/xml/rows_marathi.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.091%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml/rows_mongolian.xml
+++ b/app/src/main/res/xml/rows_mongolian.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.091%p"
     >

--- a/app/src/main/res/xml/rows_nepali_romanized.xml
+++ b/app/src/main/res/xml/rows_nepali_romanized.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.091%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml/rows_nepali_traditional.xml
+++ b/app/src/main/res/xml/rows_nepali_traditional.xml
@@ -21,18 +21,8 @@
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
     <include latin:keyboardLayout="@xml/key_styles_currency" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.091%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml/rows_nordic.xml
+++ b/app/src/main/res/xml/rows_nordic.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.091%p"
     >

--- a/app/src/main/res/xml/rows_pcqwerty.xml
+++ b/app/src/main/res/xml/rows_pcqwerty.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="7.692%p"
     >

--- a/app/src/main/res/xml/rows_qwerty.xml
+++ b/app/src/main/res/xml/rows_qwerty.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-      <case
-          latin:numberRowEnabled="true"
-      >
-        <Row
-            latin:keyWidth="10%p"
-          >
-          <include
-              latin:keyboardLayout="@xml/rowkeys_symbols1" />
-        </Row>
-      </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="10%p"
     >

--- a/app/src/main/res/xml/rows_qwertz.xml
+++ b/app/src/main/res/xml/rows_qwertz.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="10%p"
     >

--- a/app/src/main/res/xml/rows_serbian_qwertz.xml
+++ b/app/src/main/res/xml/rows_serbian_qwertz.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto" >
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row latin:keyWidth="9.091%p" >
         <include latin:keyboardLayout="@xml/rowkeys_serbian_qwertz1" />
     </Row>

--- a/app/src/main/res/xml/rows_sinhala.xml
+++ b/app/src/main/res/xml/rows_sinhala.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.091%p"
         latin:keyLabelFlags="fontNormal|autoXScale"

--- a/app/src/main/res/xml/rows_south_slavic.xml
+++ b/app/src/main/res/xml/rows_south_slavic.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.091%p"
     >

--- a/app/src/main/res/xml/rows_spanish.xml
+++ b/app/src/main/res/xml/rows_spanish.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="10%p"
     >

--- a/app/src/main/res/xml/rows_swiss.xml
+++ b/app/src/main/res/xml/rows_swiss.xml
@@ -23,18 +23,8 @@
 >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.091%p"
     >

--- a/app/src/main/res/xml/rows_symbols_shift.xml
+++ b/app/src/main/res/xml/rows_symbols_shift.xml
@@ -25,18 +25,8 @@
         latin:keyboardLayout="@xml/key_styles_common" />
     <include
         latin:keyboardLayout="@xml/key_styles_currency" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="10%p"
     >

--- a/app/src/main/res/xml/rows_tamil.xml
+++ b/app/src/main/res/xml/rows_tamil.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.091%p"
         latin:keyLabelFlags="fontNormal|autoXScale"

--- a/app/src/main/res/xml/rows_telugu.xml
+++ b/app/src/main/res/xml/rows_telugu.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="9.091%p"
         latin:keyLabelFlags="fontNormal|autoXScale"

--- a/app/src/main/res/xml/rows_thai.xml
+++ b/app/src/main/res/xml/rows_thai.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.3333%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml/rows_turkish.xml
+++ b/app/src/main/res/xml/rows_turkish.xml
@@ -1,18 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="8.182%p"
         latin:keyLabelFlags="fontNormal"

--- a/app/src/main/res/xml/rows_uzbek.xml
+++ b/app/src/main/res/xml/rows_uzbek.xml
@@ -20,18 +20,8 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto" >
     <include latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row latin:keyWidth="9.091%p" >
         <include latin:keyboardLayout="@xml/rowkeys_uzbek1" />
     </Row>

--- a/app/src/main/res/xml/rows_workman.xml
+++ b/app/src/main/res/xml/rows_workman.xml
@@ -23,18 +23,8 @@
     >
     <include
         latin:keyboardLayout="@xml/key_styles_common" />
-    <switch>
-        <case
-            latin:numberRowEnabled="true"
-            >
-            <Row
-                latin:keyWidth="10%p"
-                >
-                <include
-                    latin:keyboardLayout="@xml/rowkeys_symbols1" />
-            </Row>
-        </case>
-    </switch>
+    <include
+        latin:keyboardLayout="@xml/row_optional_number_row" />
     <Row
         latin:keyWidth="10%p"
         >


### PR DESCRIPTION
Number row is now available for every keyboard, on phone or tablet. Most of the keyboards had been tested, but feel free to have a try with yours.
@qw123wh can you give this a try ? It should fix your issue from #547.