### PR TITLE
Show suggestions everywhere except in password fields

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/InputAttributes.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/InputAttributes.java
@@ -105,12 +105,12 @@ public final class InputAttributes {
 
         // TODO: Have a helper method in InputTypeUtils
         // Make sure that passwords are not displayed in {@link SuggestionStripView}.
-        final boolean shouldSuppressSuggestions = mIsPasswordField
+        final boolean shouldSuppressSuggestions = mIsPasswordField;
                 //|| InputTypeUtils.isEmailVariation(variation)
                 //|| InputType.TYPE_TEXT_VARIATION_URI == variation
                 //|| InputType.TYPE_TEXT_VARIATION_FILTER == variation
                 //|| flagNoSuggestions
-                || flagAutoComplete;
+                //|| flagAutoComplete;
         mShouldShowSuggestions = !shouldSuppressSuggestions;
 
         mShouldInsertSpacesAutomatically = InputTypeUtils.isAutoSpaceFriendlyType(inputType);

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/InputAttributes.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/InputAttributes.java
@@ -105,13 +105,7 @@ public final class InputAttributes {
 
         // TODO: Have a helper method in InputTypeUtils
         // Make sure that passwords are not displayed in {@link SuggestionStripView}.
-        final boolean shouldSuppressSuggestions = mIsPasswordField;
-                //|| InputTypeUtils.isEmailVariation(variation)
-                //|| InputType.TYPE_TEXT_VARIATION_URI == variation
-                //|| InputType.TYPE_TEXT_VARIATION_FILTER == variation
-                //|| flagNoSuggestions
-                //|| flagAutoComplete;
-        mShouldShowSuggestions = !shouldSuppressSuggestions;
+        mShouldShowSuggestions = !(mIsPasswordField || flagNoSuggestions);
 
         mShouldInsertSpacesAutomatically = InputTypeUtils.isAutoSpaceFriendlyType(inputType);
 


### PR DESCRIPTION
Often suggestions are expected, but not shown, see e.g. #507, #456, #418, #275.
This PR should enable suggestion bar everywhere except in password fields (+ found working in a quick test).

But maybe not all people may like it see e.g. #532, so it might be more sensible to add a setting that is checked somewhere in
https://github.com/openboard-team/openboard/blob/cd267b50898961a6ee109c4e116823b2a9bc203e/app/src/main/java/org/dslul/openboard/inputmethod/latin/LatinIME.java#L1602-L1611

I can do this if the change is found acceptable.