### PR TITLE
Add phantom space after characters usually followed by space

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/inputlogic/InputLogic.java
@@ -996,9 +996,15 @@ public final class InputLogic {
                 // between swappers and strippers), so we should not stay in phantom space state if
                 // the separator is a stripper. Hence the additional test above.
                 mSpaceState = SpaceState.PHANTOM;
-            }
-
-            if (mSpaceState == SpaceState.NONE && wasComposingWord && settingsValues.isUsuallyFollowedBySpace(codePoint)) {
+            } else
+                // mSpaceState is still SpaceState.NONE, but some characters should typically
+                // be followed by space. Set phantom space state for such characters if the user
+                // enabled the setting and was not composing a word. The latter avoids setting
+                // phantom space state when typing decimal numbers, with the drawback of not
+                // setting phantom space state after ending a sentence with a non-word.
+                if (wasComposingWord
+                    && settingsValues.mInsertMoreSpacesEnabled
+                    && settingsValues.isUsuallyFollowedBySpace(codePoint)) {
                 mSpaceState = SpaceState.PHANTOM;
             }
 

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/inputlogic/InputLogic.java
@@ -1003,7 +1003,7 @@ public final class InputLogic {
                 // phantom space state when typing decimal numbers, with the drawback of not
                 // setting phantom space state after ending a sentence with a non-word.
                 if (wasComposingWord
-                    && settingsValues.mInsertMoreSpacesEnabled
+                    && settingsValues.mAutospaceAfterPunctuationEnabled
                     && settingsValues.isUsuallyFollowedBySpace(codePoint)) {
                 mSpaceState = SpaceState.PHANTOM;
             }

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/inputlogic/InputLogic.java
@@ -998,6 +998,10 @@ public final class InputLogic {
                 mSpaceState = SpaceState.PHANTOM;
             }
 
+            if (mSpaceState == SpaceState.NONE && wasComposingWord && settingsValues.isUsuallyFollowedBySpace(codePoint)) {
+                mSpaceState = SpaceState.PHANTOM;
+            }
+
             sendKeyCodePoint(settingsValues, codePoint);
 
             // Set punctuation right away. onUpdateSelection will fire but tests whether it is

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
@@ -94,6 +94,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_KEYBOARD_HEIGHT_SCALE = "pref_keyboard_height_scale";
     public static final String PREF_SPACE_TRACKPAD = "pref_space_trackpad";
     public static final String PREF_DELETE_SWIPE = "pref_delete_swipe";
+    public static final String PREF_INSERT_MORE_SPACES = "pref_insert_more_spaces";
     public static final String PREF_ALWAYS_INCOGNITO_MODE =
             "pref_always_incognito_mode";
     public static final String PREF_BIGRAM_PREDICTIONS = "next_word_prediction";
@@ -390,6 +391,10 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
 
     public static boolean readDeleteSwipeEnabled(final SharedPreferences prefs) {
         return prefs.getBoolean(PREF_DELETE_SWIPE, true);
+    }
+
+    public static boolean readInsertMoreSpacesEnabled(final SharedPreferences prefs) {
+        return prefs.getBoolean(PREF_INSERT_MORE_SPACES, false);
     }
 
     public static boolean readUseFullscreenMode(final Resources res) {

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
@@ -94,7 +94,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_KEYBOARD_HEIGHT_SCALE = "pref_keyboard_height_scale";
     public static final String PREF_SPACE_TRACKPAD = "pref_space_trackpad";
     public static final String PREF_DELETE_SWIPE = "pref_delete_swipe";
-    public static final String PREF_INSERT_MORE_SPACES = "pref_insert_more_spaces";
+    public static final String PREF_AUTOSPACE_AFTER_PUNCTUATION = "pref_autospace_after_punctuation";
     public static final String PREF_ALWAYS_INCOGNITO_MODE =
             "pref_always_incognito_mode";
     public static final String PREF_BIGRAM_PREDICTIONS = "next_word_prediction";
@@ -393,8 +393,8 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
         return prefs.getBoolean(PREF_DELETE_SWIPE, true);
     }
 
-    public static boolean readInsertMoreSpacesEnabled(final SharedPreferences prefs) {
-        return prefs.getBoolean(PREF_INSERT_MORE_SPACES, false);
+    public static boolean readAutospaceAfterPunctuationEnabled(final SharedPreferences prefs) {
+        return prefs.getBoolean(PREF_AUTOSPACE_AFTER_PUNCTUATION, false);
     }
 
     public static boolean readUseFullscreenMode(final Resources res) {

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsValues.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsValues.java
@@ -80,7 +80,7 @@ public class SettingsValues {
     public final boolean mBlockPotentiallyOffensive;
     public final boolean mSpaceTrackpadEnabled;
     public final boolean mDeleteSwipeEnabled;
-    public final boolean mInsertMoreSpacesEnabled;
+    public final boolean mAutospaceAfterPunctuationEnabled;
     public final boolean mClipboardHistoryEnabled;
     public final long mClipboardHistoryRetentionTime;
     public final boolean mOneHandedModeEnabled;
@@ -238,7 +238,7 @@ public class SettingsValues {
         }
         mSpaceTrackpadEnabled = Settings.readSpaceTrackpadEnabled(prefs);
         mDeleteSwipeEnabled = Settings.readDeleteSwipeEnabled(prefs);
-        mInsertMoreSpacesEnabled = Settings.readInsertMoreSpacesEnabled(prefs);
+        mAutospaceAfterPunctuationEnabled = Settings.readAutospaceAfterPunctuationEnabled(prefs);
         mClipboardHistoryEnabled = Settings.readClipboardHistoryEnabled(prefs);
         mClipboardHistoryRetentionTime = Settings.readClipboardHistoryRetentionTime(prefs, res);
         mOneHandedModeEnabled = Settings.readOneHandedModeEnabled(prefs);

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsValues.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsValues.java
@@ -80,6 +80,7 @@ public class SettingsValues {
     public final boolean mBlockPotentiallyOffensive;
     public final boolean mSpaceTrackpadEnabled;
     public final boolean mDeleteSwipeEnabled;
+    public final boolean mInsertMoreSpacesEnabled;
     public final boolean mClipboardHistoryEnabled;
     public final long mClipboardHistoryRetentionTime;
     public final boolean mOneHandedModeEnabled;
@@ -237,6 +238,7 @@ public class SettingsValues {
         }
         mSpaceTrackpadEnabled = Settings.readSpaceTrackpadEnabled(prefs);
         mDeleteSwipeEnabled = Settings.readDeleteSwipeEnabled(prefs);
+        mInsertMoreSpacesEnabled = Settings.readInsertMoreSpacesEnabled(prefs);
         mClipboardHistoryEnabled = Settings.readClipboardHistoryEnabled(prefs);
         mClipboardHistoryRetentionTime = Settings.readClipboardHistoryRetentionTime(prefs, res);
         mOneHandedModeEnabled = Settings.readOneHandedModeEnabled(prefs);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -187,9 +187,9 @@
     <!-- Description for "space_trackpad" option. -->
     <string name="space_trackpad_summary">Swipe on the spacebar to move the cursor</string>
     <!-- Preferences item for enabling inserting more spaces key -->
-    <string name="insert_more_spaces">Insert spaces after punctuation</string>
+    <string name="autospace_after_punctuation">Autospace after punctuation</string>
     <!-- Description for "insert_more_spaces" option. -->
-    <string name="insert_more_spaces_summary">Automatically insert space after punctuation, even if the previous word was not a suggestion</string>
+    <string name="autospace_after_punctuation_summary">Automatically insert space after punctuation when typing a new word</string>
     <!-- Preferences item for disabling word learning -->
     <string name="prefs_force_incognito_mode">Force incognito mode</string>
     <!-- Description for "prefs_force_incognito_mode" option. -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -186,6 +186,10 @@
     <string name="space_trackpad">Space bar trackpad</string>
     <!-- Description for "space_trackpad" option. -->
     <string name="space_trackpad_summary">Swipe on the spacebar to move the cursor</string>
+    <!-- Preferences item for enabling inserting more spaces key -->
+    <string name="insert_more_spaces">Insert spaces after punctuation</string>
+    <!-- Description for "insert_more_spaces" option. -->
+    <string name="insert_more_spaces_summary">Automatically insert space after punctuation, even if the previous word was not a suggestion</string>
     <!-- Preferences item for disabling word learning -->
     <string name="prefs_force_incognito_mode">Force incognito mode</string>
     <!-- Description for "prefs_force_incognito_mode" option. -->

--- a/app/src/main/res/xml/prefs_screen_advanced.xml
+++ b/app/src/main/res/xml/prefs_screen_advanced.xml
@@ -76,6 +76,12 @@
             android:summary="@string/delete_swipe_summary"
             android:defaultValue="true" />
 
+        <CheckBoxPreference
+            android:key="pref_insert_more_spaces"
+            android:title="@string/insert_more_spaces"
+            android:summary="@string/insert_more_spaces_summary"
+            android:defaultValue="false" />
+
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/app/src/main/res/xml/prefs_screen_advanced.xml
+++ b/app/src/main/res/xml/prefs_screen_advanced.xml
@@ -77,9 +77,9 @@
             android:defaultValue="true" />
 
         <CheckBoxPreference
-            android:key="pref_insert_more_spaces"
-            android:title="@string/insert_more_spaces"
-            android:summary="@string/insert_more_spaces_summary"
+            android:key="pref_autospace_after_punctuation"
+            android:title="@string/autospace_after_punctuation"
+            android:summary="@string/autospace_after_punctuation_summary"
             android:defaultValue="false" />
 
     </PreferenceCategory>


### PR DESCRIPTION
When tapping a suggestion, a phantom space is added, and this phantom space is kept if a "character usually followed by space" (e.g. punctuation) is entered, so that on starting the next word the space is inserted.

When writing a word without tapping a suggestion, no phantom space is added and thus the user needs to add the space after punctuation (and other characters) manually, which I and others (#252) find rather annoying and inconsistent (why is it added when tapping suggestion, but not when typing the word manually).

With this PR, a phantom space is added when entering a separator that is "usually followed by space", if the user "was composing a word". The latter restriction is necessary to avoid auto-inserting spaces when trying to enter decimal numbers.

A problem that remains is that when ending a sentence on a number, there will not be a phantom space. This is the same behavior as on Gboard, but still not good.
[Edit: I was wrong, Gboard does not insert a space when not using suggestions, same as current OpenBoard]

I tried inserting
```java
        if (SpaceState.NONE == inputTransaction.getMSpaceState() && settingsValues.isUsuallyFollowedBySpace(mConnection.getCodePointBeforeCursor()) && Character.isLetter(codePoint)) {
            insertAutomaticSpaceIfOptionsAndTextAllow(settingsValues);
        }
```
in line 839 (when entering a non-separator, e.g. a letter) instead of the proposed change.
Then spaces are added even if sentence ends on a number, but the first word in the new sentence isn't capitalised. I think this would be much worse than the flaw of my proposed change...
[Edit: and then it becomes impossible to remove an unwanted inserted space without moving the cursor]

Fixes #252
Fixes #563 