### PR TITLE
Add multilingual typing

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/MainKeyboardView.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/MainKeyboardView.java
@@ -55,10 +55,13 @@ import org.dslul.openboard.inputmethod.latin.SuggestedWords;
 import org.dslul.openboard.inputmethod.latin.common.Constants;
 import org.dslul.openboard.inputmethod.latin.common.CoordinateUtils;
 import org.dslul.openboard.inputmethod.latin.settings.DebugSettings;
+import org.dslul.openboard.inputmethod.latin.settings.Settings;
+import org.dslul.openboard.inputmethod.latin.settings.SettingsValues;
 import org.dslul.openboard.inputmethod.latin.utils.DeviceProtectedUtils;
 import org.dslul.openboard.inputmethod.latin.utils.LanguageOnSpacebarUtils;
 import org.dslul.openboard.inputmethod.latin.utils.TypefaceUtils;
 
+import java.util.Locale;
 import java.util.WeakHashMap;
 
 import javax.annotation.Nonnull;
@@ -838,6 +841,24 @@ public final class MainKeyboardView extends KeyboardView implements DrawingProxy
     private String layoutLanguageOnSpacebar(final Paint paint,
             final RichInputMethodSubtype subtype, final int width) {
         // Choose appropriate language name to fit into the width.
+
+        final Locale secondaryLocale = Settings.getInstance().getCurrent().mSecondaryLocale;
+        if (secondaryLocale != null
+                // avoid showing same language twice
+                && !secondaryLocale.getLanguage().equals(subtype.getLocale().getLanguage())) {
+            final Locale displayLocale = getResources().getConfiguration().locale;
+            final String full = subtype.getMiddleDisplayName() + " - " +
+                    secondaryLocale.getDisplayLanguage(displayLocale);
+            if (fitsTextIntoWidth(width, full, paint)) {
+                return full;
+            }
+            final String middle = subtype.getLocale().getLanguage().toUpperCase(displayLocale) +
+                    " - " + secondaryLocale.getLanguage().toUpperCase(displayLocale);
+            if (fitsTextIntoWidth(width, middle, paint)) {
+                return middle;
+            }
+        }
+
         if (mLanguageOnSpacebarFormatType == LanguageOnSpacebarUtils.FORMAT_TYPE_FULL_LOCALE) {
             final String fullText = subtype.getFullDisplayName();
             if (fitsTextIntoWidth(width, fullText, paint)) {

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/DictionaryFacilitatorImpl.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/DictionaryFacilitatorImpl.java
@@ -412,8 +412,8 @@ public class DictionaryFacilitatorImpl implements DictionaryFacilitator {
 
         // create / load secondary dictionary
         final Locale secondaryLocale = Settings.getInstance().getCurrent().mSecondaryLocale;
-        if (secondaryLocale != null && mainDict != null &&
-                ScriptUtils.getScriptFromSpellCheckerLocale(secondaryLocale) == ScriptUtils.getScriptFromSpellCheckerLocale(mainDict.mLocale)) {
+        if (secondaryLocale != null && mDictionaryGroup != null && mDictionaryGroup.mLocale != null &&
+                ScriptUtils.getScriptFromSpellCheckerLocale(secondaryLocale) == ScriptUtils.getScriptFromSpellCheckerLocale(mDictionaryGroup.mLocale)) {
             for (final String subDictType : subDictTypesToUse) {
                 final ExpandableBinaryDictionary subDict =
                         getSubDict(subDictType, context, newLocale, null, dictNamePrefix, account);

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/AdvancedSettingsFragment.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/AdvancedSettingsFragment.java
@@ -16,14 +16,35 @@
 
 package org.dslul.openboard.inputmethod.latin.settings;
 
+import android.app.AlertDialog;
 import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.os.Bundle;
+import android.os.LocaleList;
+import android.preference.Preference;
+import android.util.ArraySet;
+import android.util.Log;
 
+import androidx.core.os.LocaleListCompat;
+
+import org.dslul.openboard.inputmethod.dictionarypack.DictionaryPackConstants;
 import org.dslul.openboard.inputmethod.latin.AudioAndHapticFeedbackManager;
 import org.dslul.openboard.inputmethod.latin.R;
 import org.dslul.openboard.inputmethod.latin.SystemBroadcastReceiver;
+import org.dslul.openboard.inputmethod.latin.common.LocaleUtils;
+import org.dslul.openboard.inputmethod.latin.utils.DialogUtils;
+import org.dslul.openboard.inputmethod.latin.utils.DictionaryInfoUtils;
+import org.dslul.openboard.inputmethod.latin.utils.ScriptUtils;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 /**
  * "Advanced" settings sub screen.
@@ -57,6 +78,16 @@ public final class AdvancedSettingsFragment extends SubScreenFragment {
         }
 
         setupKeyLongpressTimeoutSettings();
+
+        final Preference setSecondaryLocale = findPreference("pref_secondary_locale");
+        if (setSecondaryLocale != null)
+            setSecondaryLocale.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+                @Override
+                public boolean onPreferenceClick(Preference preference) {
+                    showSecondaryLocaleDialog();
+                    return true;
+                }
+            });
     }
 
 
@@ -104,5 +135,58 @@ public final class AdvancedSettingsFragment extends SubScreenFragment {
         if (key.equals(Settings.PREF_SHOW_SETUP_WIZARD_ICON)) {
             SystemBroadcastReceiver.toggleAppIcon(getActivity());
         }
+    }
+
+    private void showSecondaryLocaleDialog() {
+        // only latin for now
+        final List<String> locales = new ArrayList<String>(getAvailableDictionaryLocalesForScript(ScriptUtils.SCRIPT_LATIN));
+        final AlertDialog.Builder builder = new AlertDialog.Builder(
+                DialogUtils.getPlatformDialogThemeContext(getActivity()))
+                .setTitle(R.string.select_language)
+                .setPositiveButton(android.R.string.ok, null);
+        if (locales.isEmpty()) {
+            builder.setMessage(R.string.no_secondary_locales)
+                    .show();
+            return;
+        }
+        locales.add(getResources().getString(R.string.secondary_locale_none));
+        final CharSequence[] titles = locales.toArray(new CharSequence[0]);
+        for (int i = 0; i < titles.length -1 ; i++) {
+            titles[i] = LocaleUtils.constructLocaleFromString(titles[i].toString()).getDisplayLanguage();
+        }
+        Locale currentSecondaryLocale = Settings.getInstance().getCurrent().mSecondaryLocale;
+        int checkedItem;
+        if (currentSecondaryLocale == null)
+            checkedItem = locales.size() - 1;
+        else
+            checkedItem = locales.indexOf(currentSecondaryLocale.toString());
+
+        builder.setSingleChoiceItems(titles, checkedItem, (dialogInterface, i) -> {
+            String locale = locales.get(i);
+            if (locale.equals(getResources().getString(R.string.secondary_locale_none)))
+                locale = "";
+            getSharedPreferences().edit().putString(Settings.PREF_SECONDARY_LOCALE, locale).apply();
+            final Intent newDictBroadcast = new Intent(DictionaryPackConstants.NEW_DICTIONARY_INTENT_ACTION);
+            getActivity().sendBroadcast(newDictBroadcast);
+        });
+
+        builder.show();
+    }
+
+    private Set<String> getAvailableDictionaryLocalesForScript(int script) {
+        final Set<String> locales = new HashSet<>();
+        // TODO: get from assets
+        //   need merged "compress" PR
+        //   filter by script!
+        final File[] directoryList = DictionaryInfoUtils.getCachedDirectoryList(getActivity());
+        for (File directory : directoryList) {
+            if (!directory.isDirectory()) continue;
+            final String dirLocale =
+                    DictionaryInfoUtils.getWordListIdFromFileName(directory.getName());
+            final Locale locale = LocaleUtils.constructLocaleFromString(dirLocale);
+            if (ScriptUtils.getScriptFromSpellCheckerLocale(locale) != script) continue;
+            locales.add(locale.toString());
+        }
+        return locales;
     }
 }

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/AdvancedSettingsFragment.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/AdvancedSettingsFragment.java
@@ -16,35 +16,14 @@
 
 package org.dslul.openboard.inputmethod.latin.settings;
 
-import android.app.AlertDialog;
 import android.content.Context;
-import android.content.DialogInterface;
-import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.os.Bundle;
-import android.os.LocaleList;
-import android.preference.Preference;
-import android.util.ArraySet;
-import android.util.Log;
 
-import androidx.core.os.LocaleListCompat;
-
-import org.dslul.openboard.inputmethod.dictionarypack.DictionaryPackConstants;
 import org.dslul.openboard.inputmethod.latin.AudioAndHapticFeedbackManager;
 import org.dslul.openboard.inputmethod.latin.R;
 import org.dslul.openboard.inputmethod.latin.SystemBroadcastReceiver;
-import org.dslul.openboard.inputmethod.latin.common.LocaleUtils;
-import org.dslul.openboard.inputmethod.latin.utils.DialogUtils;
-import org.dslul.openboard.inputmethod.latin.utils.DictionaryInfoUtils;
-import org.dslul.openboard.inputmethod.latin.utils.ScriptUtils;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
 
 /**
  * "Advanced" settings sub screen.
@@ -78,16 +57,6 @@ public final class AdvancedSettingsFragment extends SubScreenFragment {
         }
 
         setupKeyLongpressTimeoutSettings();
-
-        final Preference setSecondaryLocale = findPreference("pref_secondary_locale");
-        if (setSecondaryLocale != null)
-            setSecondaryLocale.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
-                @Override
-                public boolean onPreferenceClick(Preference preference) {
-                    showSecondaryLocaleDialog();
-                    return true;
-                }
-            });
     }
 
 
@@ -135,68 +104,5 @@ public final class AdvancedSettingsFragment extends SubScreenFragment {
         if (key.equals(Settings.PREF_SHOW_SETUP_WIZARD_ICON)) {
             SystemBroadcastReceiver.toggleAppIcon(getActivity());
         }
-    }
-
-    private void showSecondaryLocaleDialog() {
-        // only allow same script of main locale for now
-        // TODO: how to get enabled keyboard locales? then setting a secondary locale per
-        //  main locale would be rather simple
-        final SettingsValues settingsValues = Settings.getInstance().getCurrent();
-        final int scriptOfCurrentLocale = ScriptUtils.getScriptFromSpellCheckerLocale(settingsValues.mLocale);
-        final List<String> locales = new ArrayList<String>(getAvailableDictionaryLocalesForScript(scriptOfCurrentLocale));
-        final AlertDialog.Builder builder = new AlertDialog.Builder(
-                DialogUtils.getPlatformDialogThemeContext(getActivity()))
-                .setTitle(R.string.select_language)
-                .setPositiveButton(android.R.string.ok, null);
-
-        if (locales.isEmpty()) {
-            builder.setMessage(R.string.no_secondary_locales)
-                    .show();
-            return;
-        }
-
-        // add "no secondary language" option
-        locales.add(getResources().getString(R.string.secondary_locale_none));
-
-        final CharSequence[] titles = locales.toArray(new CharSequence[0]);
-        for (int i = 0; i < titles.length - 1 ; i++) {
-            final Locale loc = LocaleUtils.constructLocaleFromString(titles[i].toString());
-            titles[i] = loc.getDisplayLanguage(settingsValues.mLocale);
-        }
-
-        Locale currentSecondaryLocale = settingsValues.mSecondaryLocale;
-        int checkedItem;
-        if (currentSecondaryLocale == null)
-            checkedItem = locales.size() - 1;
-        else
-            checkedItem = locales.indexOf(currentSecondaryLocale.toString());
-
-        builder.setSingleChoiceItems(titles, checkedItem, (dialogInterface, i) -> {
-            String locale = locales.get(i);
-            if (i == locales.size() - 1)
-                locale = "";
-            getSharedPreferences().edit().putString(Settings.PREF_SECONDARY_LOCALE, locale).apply();
-            final Intent newDictBroadcast = new Intent(DictionaryPackConstants.NEW_DICTIONARY_INTENT_ACTION);
-            getActivity().sendBroadcast(newDictBroadcast);
-        });
-
-        builder.show();
-    }
-
-    private Set<String> getAvailableDictionaryLocalesForScript(int script) {
-        final Set<String> locales = new HashSet<>();
-        // TODO: get from assets
-        //   need merged "compress" PR
-        //   filter by script!
-        final File[] directoryList = DictionaryInfoUtils.getCachedDirectoryList(getActivity());
-        for (File directory : directoryList) {
-            if (!directory.isDirectory()) continue;
-            final String dirLocale =
-                    DictionaryInfoUtils.getWordListIdFromFileName(directory.getName());
-            final Locale locale = LocaleUtils.constructLocaleFromString(dirLocale);
-            if (ScriptUtils.getScriptFromSpellCheckerLocale(locale) != script) continue;
-            locales.add(locale.toString());
-        }
-        return locales;
     }
 }

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SecondaryLocaleSettingsFragment.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SecondaryLocaleSettingsFragment.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2012 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dslul.openboard.inputmethod.latin.settings;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.preference.Preference;
+import android.view.inputmethod.InputMethodSubtype;
+
+import org.dslul.openboard.inputmethod.dictionarypack.DictionaryPackConstants;
+import org.dslul.openboard.inputmethod.latin.BuildConfig;
+import org.dslul.openboard.inputmethod.latin.R;
+import org.dslul.openboard.inputmethod.latin.RichInputMethodManager;
+import org.dslul.openboard.inputmethod.latin.common.LocaleUtils;
+import org.dslul.openboard.inputmethod.latin.utils.DialogUtils;
+import org.dslul.openboard.inputmethod.latin.utils.DictionaryInfoUtils;
+import org.dslul.openboard.inputmethod.latin.utils.ScriptUtils;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+public final class SecondaryLocaleSettingsFragment extends SubScreenFragment {
+    private RichInputMethodManager mRichImm;
+    private SharedPreferences mPrefs;
+
+    @Override
+    public void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        RichInputMethodManager.init(getActivity());
+        mRichImm = RichInputMethodManager.getInstance();
+        addPreferencesFromResource(R.xml.additional_subtype_settings);
+        resetKeyboardLocales();
+    }
+
+    private void resetKeyboardLocales() {
+        getPreferenceScreen().removeAll();
+        final Context context = getActivity();
+        List<InputMethodSubtype> subtypes = mRichImm.getMyEnabledInputMethodSubtypeList(false);
+
+        for (InputMethodSubtype subtype : subtypes) {
+            final Locale secondaryLocale = Settings.getSecondaryLocale(getSharedPreferences(), subtype.getLocale());
+            final Preference pref = new Preference(context);
+            pref.setTitle(subtype.getDisplayName(context, BuildConfig.APPLICATION_ID, context.getApplicationInfo()));
+            if (secondaryLocale != null)
+                pref.setSummary(secondaryLocale.getDisplayLanguage(getResources().getConfiguration().locale));
+
+            pref.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+                @Override
+                public boolean onPreferenceClick(Preference preference) {
+                    showSecondaryLocaleDialog(subtype.getLocale(), subtype.isAsciiCapable());
+                    return true;
+                }
+            });
+            getPreferenceScreen().addPreference(pref);
+        }
+
+    }
+
+    private void showSecondaryLocaleDialog(String mainLocale, boolean asciiCapable) {
+        final SettingsValues settingsValues = Settings.getInstance().getCurrent();
+        // TODO: does this really return latin for persian? might need that huge map from somewhere github
+        //  or maybe extend the script map, also with exception for sr_ZZ
+        //  but: could this break other things?
+
+        final List<String> locales = new ArrayList<>(getAvailableDictionaryLocales(mainLocale, asciiCapable));
+        final AlertDialog.Builder builder = new AlertDialog.Builder(
+                DialogUtils.getPlatformDialogThemeContext(getActivity()))
+                .setTitle(R.string.language_selection_title)
+                .setPositiveButton(android.R.string.ok, null);
+
+        if (locales.isEmpty()) {
+            builder.setMessage(R.string.no_secondary_locales)
+                    .show();
+            return;
+        }
+
+        // add "no secondary language" option
+        locales.add(getResources().getString(R.string.secondary_locale_none));
+
+        final CharSequence[] titles = locales.toArray(new CharSequence[0]);
+        for (int i = 0; i < titles.length - 1 ; i++) {
+            final Locale loc = LocaleUtils.constructLocaleFromString(titles[i].toString());
+            titles[i] = loc.getDisplayLanguage(settingsValues.mLocale);
+        }
+
+        Locale currentSecondaryLocale = settingsValues.mSecondaryLocale;
+        int checkedItem;
+        if (currentSecondaryLocale == null)
+            checkedItem = locales.size() - 1;
+        else
+            checkedItem = locales.indexOf(currentSecondaryLocale.toString());
+
+        builder.setSingleChoiceItems(titles, checkedItem, (dialogInterface, i) -> {
+            String locale = locales.get(i);
+            if (i == locales.size() - 1)
+                locale = "";
+            final Set<String> encodedLocales = new HashSet<>();
+            boolean updated = false;
+            for (String encodedLocale : getSharedPreferences().getStringSet(Settings.PREF_SECONDARY_LOCALES, new HashSet<>())) {
+                String[] locs = encodedLocale.split("§");
+                if (locs.length == 2 && locs[0].equals(mainLocale)) {
+                    if (!locale.isEmpty())
+                        encodedLocales.add(mainLocale + "§" + locale);
+                    updated = true;
+                } else {
+                    encodedLocales.add(encodedLocale);
+                }
+            }
+            if (!updated)
+                encodedLocales.add(mainLocale + "§" + locale);
+            getSharedPreferences().edit().putStringSet(Settings.PREF_SECONDARY_LOCALES, encodedLocales).apply();
+ //           getSharedPreferences().edit().putString(Settings.PREF_SECONDARY_LOCALE, locale).apply();
+            final Intent newDictBroadcast = new Intent(DictionaryPackConstants.NEW_DICTIONARY_INTENT_ACTION);
+            getActivity().sendBroadcast(newDictBroadcast);
+            resetKeyboardLocales();
+        });
+
+        builder.show();
+    }
+
+    // get locales with same script as main locale, but different language
+    private Set<String> getAvailableDictionaryLocales(String mainLocale, boolean asciiCapable) {
+        final Locale mainL = LocaleUtils.constructLocaleFromString(mainLocale);
+        final int mainScript;
+        if (asciiCapable)
+            mainScript = ScriptUtils.SCRIPT_LATIN;
+        else
+            mainScript = ScriptUtils.getScriptFromSpellCheckerLocale(mainL);
+
+        final Set<String> locales = new HashSet<>();
+
+        // TODO: also get locales from assets
+        //   need merged "compress" PR
+        final File[] directoryList = DictionaryInfoUtils.getCachedDirectoryList(getActivity());
+        for (File directory : directoryList) {
+            if (!directory.isDirectory()) continue;
+            final String dirLocale =
+                    DictionaryInfoUtils.getWordListIdFromFileName(directory.getName());
+            if (dirLocale.equals(mainLocale)) continue;
+            final Locale locale = LocaleUtils.constructLocaleFromString(dirLocale);
+            if (locale.getLanguage().equals(mainL.getLanguage())) continue;
+            int localeScript = ScriptUtils.getScriptFromSpellCheckerLocale(locale);
+            if (localeScript != mainScript) continue;
+            locales.add(locale.toString());
+        }
+        return locales;
+    }
+
+}

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SecondaryLocaleSettingsFragment.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SecondaryLocaleSettingsFragment.java
@@ -55,7 +55,7 @@ public final class SecondaryLocaleSettingsFragment extends SubScreenFragment {
         mRichImm.refreshSubtypeCaches();
         getPreferenceScreen().removeAll();
         final Context context = getActivity();
-        List<InputMethodSubtype> subtypes = mRichImm.getMyEnabledInputMethodSubtypeList(false);
+        List<InputMethodSubtype> subtypes = mRichImm.getMyEnabledInputMethodSubtypeList(true);
 
         for (InputMethodSubtype subtype : subtypes) {
             final Locale secondaryLocale = Settings.getSecondaryLocale(getSharedPreferences(), subtype.getLocale());
@@ -150,6 +150,21 @@ public final class SecondaryLocaleSettingsFragment extends SubScreenFragment {
 
         // TODO: also get locales from assets
         //   need merged "compress" PR
+        // for testing: add some latin locales
+        if (asciiCapable) {
+            locales.add("da");
+            locales.add("de");
+            locales.add("en");
+            locales.add("es");
+            locales.add("fr");
+            locales.add("hu");
+            locales.add("it");
+            locales.add("nl");
+            locales.add("pl");
+            locales.add("ro");
+            locales.add("tr");
+            locales.add("sv");
+        }
         final File[] directoryList = DictionaryInfoUtils.getCachedDirectoryList(getActivity());
         for (File directory : directoryList) {
             if (!directory.isDirectory()) continue;

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SecondaryLocaleSettingsFragment.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SecondaryLocaleSettingsFragment.java
@@ -67,7 +67,7 @@ public final class SecondaryLocaleSettingsFragment extends SubScreenFragment {
             pref.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
                 @Override
                 public boolean onPreferenceClick(Preference preference) {
-                    showSecondaryLocaleDialog(subtype.getLocale(), subtype.isAsciiCapable());
+                    showSecondaryLocaleDialog(subtype.getLocale().toLowerCase(Locale.ENGLISH), subtype.isAsciiCapable());
                     return true;
                 }
             });

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SecondaryLocaleSettingsFragment.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SecondaryLocaleSettingsFragment.java
@@ -136,14 +136,17 @@ public final class SecondaryLocaleSettingsFragment extends SubScreenFragment {
     // get locales with same script as main locale, but different language
     private Set<String> getAvailableDictionaryLocales(String mainLocale, boolean asciiCapable) {
         final Locale mainL = LocaleUtils.constructLocaleFromString(mainLocale);
+        final Set<String> locales = new HashSet<>();
         final int mainScript;
         if (asciiCapable)
             mainScript = ScriptUtils.SCRIPT_LATIN;
         else
             mainScript = ScriptUtils.getScriptFromSpellCheckerLocale(mainL);
-        // TODO: does this really return latin for persian? might need that huge map from somewhere github
-
-        final Set<String> locales = new HashSet<>();
+        // ScriptUtils.getScriptFromSpellCheckerLocale may return latin when it should not
+        //  e.g. for persian or chinese
+        // workaround: don't allow secondary locales for these locales
+        if (!asciiCapable && mainScript == ScriptUtils.SCRIPT_LATIN)
+            return locales;
 
         // TODO: also get locales from assets
         //   need merged "compress" PR

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
@@ -514,12 +514,11 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
         return prefs.getInt(PREF_LAST_SHOWN_EMOJI_CATEGORY_PAGE_ID, defValue);
     }
 
-    // TODO: test whether this gets updated on keyboard language switch!
     public static Locale getSecondaryLocale(final SharedPreferences prefs, final String mainLocaleString) {
         final Set<String> encodedLocales = prefs.getStringSet(PREF_SECONDARY_LOCALES, new HashSet<>());
         for (String loc : encodedLocales) {
             String[] locales = loc.split("§");
-            if (locales.length == 2 && locales[0].equals(mainLocaleString))
+            if (locales.length == 2 && locales[0].equals(mainLocaleString.toLowerCase(Locale.ENGLISH)))
                 return LocaleUtils.constructLocaleFromString(locales[1]);
         }
         return null;

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
@@ -36,9 +36,11 @@ import org.dslul.openboard.inputmethod.latin.utils.DeviceProtectedUtils;
 import org.dslul.openboard.inputmethod.latin.utils.JniUtils;
 import org.dslul.openboard.inputmethod.latin.utils.ResourceUtils;
 import org.dslul.openboard.inputmethod.latin.utils.RunInLocale;
+import org.dslul.openboard.inputmethod.latin.utils.ScriptUtils;
 import org.dslul.openboard.inputmethod.latin.utils.StatsUtils;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
@@ -127,7 +129,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_ENABLE_CLIPBOARD_HISTORY = "pref_enable_clipboard_history";
     public static final String PREF_CLIPBOARD_HISTORY_RETENTION_TIME = "pref_clipboard_history_retention_time";
 
-    public static final String PREF_SECONDARY_LOCALE = "pref_secondary_locale";
+    public static final String PREF_SECONDARY_LOCALES = "pref_secondary_locales";
 
     // This preference key is deprecated. Use {@link #PREF_SHOW_LANGUAGE_SWITCH_KEY} instead.
     // This is being used only for the backward compatibility.
@@ -512,11 +514,15 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
         return prefs.getInt(PREF_LAST_SHOWN_EMOJI_CATEGORY_PAGE_ID, defValue);
     }
 
-    public static Locale readSecondaryLocale(final SharedPreferences prefs) {
-        final String localeString = prefs.getString(PREF_SECONDARY_LOCALE, "");
-        if (localeString.isEmpty())
-            return null;
-        return LocaleUtils.constructLocaleFromString(localeString);
+    // TODO: test whether this gets updated on keyboard language switch!
+    public static Locale getSecondaryLocale(final SharedPreferences prefs, final String mainLocaleString) {
+        final Set<String> encodedLocales = prefs.getStringSet(PREF_SECONDARY_LOCALES, new HashSet<>());
+        for (String loc : encodedLocales) {
+            String[] locales = loc.split("§");
+            if (locales.length == 2 && locales[0].equals(mainLocaleString))
+                return LocaleUtils.constructLocaleFromString(locales[1]);
+        }
+        return null;
     }
 
     private void upgradeAutocorrectionSettings(final SharedPreferences prefs, final Resources res) {

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
@@ -29,6 +29,7 @@ import android.view.Gravity;
 import org.dslul.openboard.inputmethod.latin.AudioAndHapticFeedbackManager;
 import org.dslul.openboard.inputmethod.latin.InputAttributes;
 import org.dslul.openboard.inputmethod.latin.R;
+import org.dslul.openboard.inputmethod.latin.common.LocaleUtils;
 import org.dslul.openboard.inputmethod.latin.common.StringUtils;
 import org.dslul.openboard.inputmethod.latin.utils.AdditionalSubtypeUtils;
 import org.dslul.openboard.inputmethod.latin.utils.DeviceProtectedUtils;
@@ -125,6 +126,8 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
 
     public static final String PREF_ENABLE_CLIPBOARD_HISTORY = "pref_enable_clipboard_history";
     public static final String PREF_CLIPBOARD_HISTORY_RETENTION_TIME = "pref_clipboard_history_retention_time";
+
+    public static final String PREF_SECONDARY_LOCALE = "pref_secondary_locale";
 
     // This preference key is deprecated. Use {@link #PREF_SHOW_LANGUAGE_SWITCH_KEY} instead.
     // This is being used only for the backward compatibility.
@@ -507,6 +510,13 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static int readLastShownEmojiCategoryPageId(
             final SharedPreferences prefs, final int defValue) {
         return prefs.getInt(PREF_LAST_SHOWN_EMOJI_CATEGORY_PAGE_ID, defValue);
+    }
+
+    public static Locale readSecondaryLocale(final SharedPreferences prefs) {
+        final String localeString = prefs.getString(PREF_SECONDARY_LOCALE, "");
+        if (localeString.isEmpty())
+            return null;
+        return LocaleUtils.constructLocaleFromString(localeString);
     }
 
     private void upgradeAutocorrectionSettings(final SharedPreferences prefs, final Resources res) {

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsValues.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsValues.java
@@ -36,6 +36,7 @@ import org.dslul.openboard.inputmethod.latin.utils.TargetPackageInfoGetterTask;
 
 import java.util.Arrays;
 import java.util.Locale;
+import java.util.Map;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -85,6 +86,7 @@ public class SettingsValues {
     public final boolean mOneHandedModeEnabled;
     public final int mOneHandedModeGravity;
     public final Locale mSecondaryLocale;
+//    public final Map<Locale, Locale> mSecondaryLocales;
     // Use bigrams to predict the next word when there is no input for it yet
     public final boolean mBigramPredictionEnabled;
     public final boolean mGestureInputEnabled;
@@ -242,7 +244,7 @@ public class SettingsValues {
         mClipboardHistoryRetentionTime = Settings.readClipboardHistoryRetentionTime(prefs, res);
         mOneHandedModeEnabled = Settings.readOneHandedModeEnabled(prefs);
         mOneHandedModeGravity = Settings.readOneHandedModeGravity(prefs);
-        mSecondaryLocale = Settings.readSecondaryLocale(prefs);
+        mSecondaryLocale = Settings.getSecondaryLocale(prefs, RichInputMethodManager.getInstance().getCurrentSubtypeLocale().toString());
     }
 
     public boolean isMetricsLoggingEnabled() {

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsValues.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsValues.java
@@ -84,6 +84,7 @@ public class SettingsValues {
     public final long mClipboardHistoryRetentionTime;
     public final boolean mOneHandedModeEnabled;
     public final int mOneHandedModeGravity;
+    public final Locale mSecondaryLocale;
     // Use bigrams to predict the next word when there is no input for it yet
     public final boolean mBigramPredictionEnabled;
     public final boolean mGestureInputEnabled;
@@ -241,6 +242,7 @@ public class SettingsValues {
         mClipboardHistoryRetentionTime = Settings.readClipboardHistoryRetentionTime(prefs, res);
         mOneHandedModeEnabled = Settings.readOneHandedModeEnabled(prefs);
         mOneHandedModeGravity = Settings.readOneHandedModeGravity(prefs);
+        mSecondaryLocale = Settings.readSecondaryLocale(prefs);
     }
 
     public boolean isMetricsLoggingEnabled() {

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/ScriptUtils.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/ScriptUtils.java
@@ -201,6 +201,9 @@ public class ScriptUtils {
      * {@see http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes}
      */
     public static int getScriptFromSpellCheckerLocale(final Locale locale) {
+        // need special treatment of serbian latin, which would get detected as cyrillic
+        if (locale.toString().equals("sr_ZZ"))
+            return ScriptUtils.SCRIPT_LATIN;
         String language = locale.getLanguage();
         Integer script = mLanguageCodeToScriptCode.get(language);
         if (script == null) {

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/ScriptUtils.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/ScriptUtils.java
@@ -202,7 +202,7 @@ public class ScriptUtils {
      */
     public static int getScriptFromSpellCheckerLocale(final Locale locale) {
         // need special treatment of serbian latin, which would get detected as cyrillic
-        if (locale.toString().equals("sr_ZZ"))
+        if (locale.toString().toLowerCase(Locale.ENGLISH).equals("sr_zz"))
             return ScriptUtils.SCRIPT_LATIN;
         String language = locale.getLanguage();
         Integer script = mLanguageCodeToScriptCode.get(language);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -189,9 +189,11 @@
     <!-- Description for "secondary_locale" option. -->
     <string name="secondary_locale_summary">Select a secondary dictionary to use alongside main language</string>
     <!-- Text when no secondary locale chosen -->
+    <string name="select_main_locale">Select keyboard for secondary dictionary</string>
+    <!-- Text when no secondary locale chosen -->
     <string name="secondary_locale_none">None</string>
     <!-- Message shown when no secondary locales available -->
-    <string name="no_secondary_locales">No secondary locales available</string>
+    <string name="no_secondary_locales">No secondary dictionaries available</string>
     <!-- Description for "space_trackpad" option. -->
     <string name="space_trackpad_summary">Swipe on the spacebar to move the cursor</string>
     <!-- Preferences item for disabling word learning -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -184,6 +184,14 @@
     <string name="delete_swipe_summary">Perform a swipe from the delete key to select and remove bigger portions of text at once</string>
     <!-- Preferences item for enabling trackpad space key -->
     <string name="space_trackpad">Space bar trackpad</string>
+    <!-- Preferences item for choosing secondary language -->
+    <string name="secondary_locale">Multilingual typing</string>
+    <!-- Description for "secondary_locale" option. -->
+    <string name="secondary_locale_summary">Select a secondary dictionary to use alongside main language</string>
+    <!-- Text when no secondary locale chosen -->
+    <string name="secondary_locale_none">None</string>
+    <!-- Message shown when no secondary locales available -->
+    <string name="no_secondary_locales">No secondary locales available</string>
     <!-- Description for "space_trackpad" option. -->
     <string name="space_trackpad_summary">Swipe on the spacebar to move the cursor</string>
     <!-- Preferences item for disabling word learning -->

--- a/app/src/main/res/xml/prefs_screen_advanced.xml
+++ b/app/src/main/res/xml/prefs_screen_advanced.xml
@@ -76,8 +76,9 @@
             android:summary="@string/delete_swipe_summary"
             android:defaultValue="true" />
 
-        <Preference
-            android:key="pref_secondary_locale"
+        <PreferenceScreen
+            android:fragment="org.dslul.openboard.inputmethod.latin.settings.SecondaryLocaleSettingsFragment"
+            android:key="pref_secondary_locales"
             android:title="@string/secondary_locale"
             android:summary="@string/secondary_locale_summary" />
 

--- a/app/src/main/res/xml/prefs_screen_advanced.xml
+++ b/app/src/main/res/xml/prefs_screen_advanced.xml
@@ -76,6 +76,11 @@
             android:summary="@string/delete_swipe_summary"
             android:defaultValue="true" />
 
+        <Preference
+            android:key="pref_secondary_locale"
+            android:title="@string/secondary_locale"
+            android:summary="@string/secondary_locale_summary" />
+
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
This is a very basic implementation of multilingual typing, but it is working.

A second dictionary is added in and queried for suggestions, so that suggestions of both languages show up. The secondary language has lower weight, so mostly suggestions of the main language are shown. If more than two consecutive typed words exist only in the secondary language, main and secondary language switch roles.

This is only a draft PR, because a lot of stuff needs to be done:
* secondary language is currently hardcoded, but in the end must be selectable (or disabled) by user
* the secondary dictionary is only loaded once, and can't ever be changed or closed
* the current main language is not stored, so it will reset whenever the app is closed
* spell checker (if enabled) only works for the initial main language and does not switch (not sure if this can actually be changed)
* current main language should be shown somewhere (on space bar?)
* some tuning of suggestion weights main vs seccondary language

Before I continue working on this I would like some feedback on whether the way I did it is acceptable at all, and maybe some general comments on what should be taken care of.

fixes #167 
fixes #7