### PR TITLE
Reduce sensitivty of space / delete gestures

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/PointerTracker.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/PointerTracker.java
@@ -16,6 +16,8 @@
 
 package org.dslul.openboard.inputmethod.keyboard;
 
+import static java.lang.Math.abs;
+
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.os.SystemClock;
@@ -907,7 +909,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         if (oldKey != null && oldKey.getCode() == Constants.CODE_SPACE && Settings.getInstance().getCurrent().mSpaceTrackpadEnabled) {
             //Pointer slider
             int steps = (x - mStartX) / sPointerStep;
-            final int longpressTimeout = Settings.getInstance().getCurrent().mKeyLongpressTimeout / MULTIPLIER_FOR_LONG_PRESS_TIMEOUT_IN_SLIDING_INPUT;
+            final int longpressTimeout = 2 * Settings.getInstance().getCurrent().mKeyLongpressTimeout / MULTIPLIER_FOR_LONG_PRESS_TIMEOUT_IN_SLIDING_INPUT;
             if (steps != 0 && mStartTime + longpressTimeout < System.currentTimeMillis()) {
                 mCursorMoved = true;
                 mStartX += steps * sPointerStep;
@@ -919,7 +921,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         if (oldKey != null && oldKey.getCode() == Constants.CODE_DELETE && Settings.getInstance().getCurrent().mDeleteSwipeEnabled) {
             //Delete slider
             int steps = (x - mStartX) / sPointerStep;
-            if (steps != 0) {
+            if (abs(steps) > 2 || (mCursorMoved && steps != 0)) {
                 sTimerProxy.cancelKeyTimersOf(this);
                 mCursorMoved = true;
                 mStartX += steps * sPointerStep;


### PR DESCRIPTION
As briefly discussed in #280, this adds a minimum distance to delete swipe, and increases minimum time the space bar needs to be touched for cursor movement swipe.

My reason for the two different solutions for similar problems:
* "this causes a lot of annoying typos because all of a sudden you find yourself typing right **in the middle of a previous word**" (#411) makes me think the distance threshold to fix it would need to be rather high, but this would impede intentional small cursor movements. Still, adding a small threshold in addition to increased long press time might be useful.
* I sometimes do accidental delete swipes, especially when wanting to long press delete. Since I want to long press anyway, a long press timeout would not help and a distance threshold is necessary. A long press theshold might even be bad, as it forbids performing a quick delete-all swipe.

Of course these are my personal resons for choosing the solutions, and I guess people using the keyoad a bit differently might have different needs...
So I'm definitely open for changes, especially tuning the values and adding distance threshold on space bar.

@MajeurAndroid in #280
> I think we can use the ViewConfiguration min touch slope to have a consistant behaviour, if it works well here.

I'm not sure what you had in mind here, but I found using `steps` as distance measurement works quite well, and there is no need for additional code (1 step appears to be approximately 1 character, and the steps are scaled to display density via `sPointerStep`)

Last, there is `MULTIPLIER_FOR_LONG_PRESS_TIMEOUT_IN_SLIDING_INPUT` (which is 3) which is still in use, but actually deceiving as in the end the used vlaue is 2/3. Not sure how to best do it... use 2 values, or maybe make it a float?