### PR TITLE
Invert space bar swipe direction for RTL languages

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/LatinIME.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/LatinIME.java
@@ -1393,6 +1393,10 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
 
     @Override
     public void onMovePointer(int steps) {
+        // for RTL languages we want to invert pointer movement
+        if (mRichImm.getCurrentSubtype().isRtlSubtype())
+            steps = -steps;
+            
         mInputLogic.finishInput();
         if (steps < 0) {
             int availableCharacters = mInputLogic.mConnection.getTextBeforeCursor(64, 0).length();


### PR DESCRIPTION
fixes #205
Other keyboards (Gboard, FlorisBoard) also do this.

There should not be any side effects, as `onMovePointer` is only called on space swipe gesture in https://github.com/openboard-team/openboard/blob/e9393dfab01dcdfb0872f360b1afe8092777f5ec/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/PointerTracker.java#L906-L919 