### PR TITLE
Hide voice input key and disable setting if no voice input available

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/InputAttributes.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/InputAttributes.java
@@ -112,7 +112,8 @@ public final class InputAttributes {
         final boolean noMicrophone = mIsPasswordField
                 || InputTypeUtils.isEmailVariation(variation)
                 || InputType.TYPE_TEXT_VARIATION_URI == variation
-                || hasNoMicrophoneKeyOption();
+                || hasNoMicrophoneKeyOption()
+                || !RichInputMethodManager.getInstance().hasShortcutIme();
         mShouldShowVoiceInputKey = !noMicrophone;
 
         mDisableGestureFloatingPreviewText = InputAttributes.inPrivateImeOptions(

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/RichInputMethodManager.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/RichInputMethodManager.java
@@ -584,6 +584,10 @@ public class RichInputMethodManager {
         switchToTargetIME(imiId, mShortcutSubtype, context);
     }
 
+    public boolean hasShortcutIme() {
+        return mShortcutInputMethodInfo != null;
+    }
+
     private void switchToTargetIME(final String imiId, final InputMethodSubtype subtype,
             final InputMethodService context) {
         final IBinder token = context.getWindow().getWindow().getAttributes().token;

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/PreferencesSettingsFragment.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/PreferencesSettingsFragment.java
@@ -70,8 +70,9 @@ public final class PreferencesSettingsFragment extends SubScreenFragment {
         final Preference voiceInputKeyOption = findPreference(Settings.PREF_VOICE_INPUT_KEY);
         if (voiceInputKeyOption != null) {
             RichInputMethodManager.getInstance().refreshSubtypeCaches();
-            voiceInputKeyOption.setEnabled(VOICE_IME_ENABLED);
-            voiceInputKeyOption.setSummary(VOICE_IME_ENABLED
+            boolean voiceKeyEnabled = VOICE_IME_ENABLED && RichInputMethodManager.getInstance().hasShortcutIme();
+            voiceInputKeyOption.setEnabled(voiceKeyEnabled);
+            voiceInputKeyOption.setSummary(voiceKeyEnabled
                     ? null : getText(R.string.voice_input_disabled_summary));
         }
     }

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsValues.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsValues.java
@@ -149,7 +149,7 @@ public class SettingsValues {
         mKeyPreviewPopupOn = Settings.readKeyPreviewPopupEnabled(prefs, res);
         mSlidingKeyInputPreviewEnabled = prefs.getBoolean(
                 DebugSettings.PREF_SLIDING_KEY_INPUT_PREVIEW, true);
-        mShowsVoiceInputKey = needsToShowVoiceInputKey(prefs, res) && mInputAttributes.mShouldShowVoiceInputKey;
+        mShowsVoiceInputKey = needsToShowVoiceInputKey(prefs, res) && mInputAttributes.mShouldShowVoiceInputKey && RichInputMethodManager.getInstance().hasShortcutIme();
         mIncludesOtherImesInLanguageSwitchList = !Settings.ENABLE_SHOW_LANGUAGE_SWITCH_KEY_SETTINGS || prefs.getBoolean(Settings.PREF_INCLUDE_OTHER_IMES_IN_LANGUAGE_SWITCH_LIST, false) /* forcibly */;
         mShowsNumberRow = prefs.getBoolean(Settings.PREF_SHOW_NUMBER_ROW, false);
         mShowsHints = prefs.getBoolean(Settings.PREF_SHOW_HINTS, true);

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsValues.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsValues.java
@@ -149,7 +149,7 @@ public class SettingsValues {
         mKeyPreviewPopupOn = Settings.readKeyPreviewPopupEnabled(prefs, res);
         mSlidingKeyInputPreviewEnabled = prefs.getBoolean(
                 DebugSettings.PREF_SLIDING_KEY_INPUT_PREVIEW, true);
-        mShowsVoiceInputKey = needsToShowVoiceInputKey(prefs, res) && mInputAttributes.mShouldShowVoiceInputKey && RichInputMethodManager.getInstance().hasShortcutIme();
+        mShowsVoiceInputKey = needsToShowVoiceInputKey(prefs, res) && mInputAttributes.mShouldShowVoiceInputKey;
         mIncludesOtherImesInLanguageSwitchList = !Settings.ENABLE_SHOW_LANGUAGE_SWITCH_KEY_SETTINGS || prefs.getBoolean(Settings.PREF_INCLUDE_OTHER_IMES_IN_LANGUAGE_SWITCH_LIST, false) /* forcibly */;
         mShowsNumberRow = prefs.getBoolean(Settings.PREF_SHOW_NUMBER_ROW, false);
         mShowsHints = prefs.getBoolean(Settings.PREF_SHOW_HINTS, true);


### PR DESCRIPTION
fixes #541 

There is already code in `PreferencesSettingsFragment` that is supposed to disable the voice input setting if no voice input is available, but appartenly it doesn't work properly.

With this PR, voice input setting is not only disabled if `VOICE_IME_ENABLED` is false, but also if `RichInputMethodManager.mShortcutInputMethodInfo` is null.
The voice input key is also disabled if `RichInputMethodManager.mShortcutInputMethodInfo` is null.

The latter should definitely be correct, as the voice input key does nothing if `RichInputMethodManager.mShortcutInputMethodInfo` is null, see https://github.com/openboard-team/openboard/blob/e9393dfab01dcdfb0872f360b1afe8092777f5ec/app/src/main/java/org/dslul/openboard/inputmethod/latin/RichInputMethodManager.java#L578-L581
`switchToShortcutIme` is called when clicking the voice input key.