### PR TITLE
Added emoji usage frequency support

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/KeyboardSwitcher.java
@@ -24,7 +24,6 @@ import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
-
 import org.dslul.openboard.inputmethod.event.Event;
 import org.dslul.openboard.inputmethod.keyboard.KeyboardLayoutSet.KeyboardLayoutSetException;
 import org.dslul.openboard.inputmethod.keyboard.clipboard.ClipboardHistoryView;
@@ -545,6 +544,7 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         mKeyboardView.setKeyboardActionListener(mLatinIME);
         mEmojiPalettesView.setHardwareAcceleratedDrawingEnabled(
                 isHardwareAcceleratedDrawingEnabled);
+        mEmojiPalettesView.setUiHandler(mLatinIME.mHandler);
         mEmojiPalettesView.setKeyboardActionListener(mLatinIME);
         mClipboardHistoryView.setHardwareAcceleratedDrawingEnabled(
                 isHardwareAcceleratedDrawingEnabled);

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/DynamicGridKeyboard.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/DynamicGridKeyboard.java
@@ -16,47 +16,39 @@
 
 package org.dslul.openboard.inputmethod.keyboard.emoji;
 
-import android.content.SharedPreferences;
 import android.text.TextUtils;
-import android.util.Log;
-
 import org.dslul.openboard.inputmethod.keyboard.Key;
 import org.dslul.openboard.inputmethod.keyboard.Keyboard;
 import org.dslul.openboard.inputmethod.keyboard.internal.MoreKeySpec;
-import org.dslul.openboard.inputmethod.latin.settings.Settings;
-import org.dslul.openboard.inputmethod.latin.utils.JsonUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * This is a Keyboard class where you can add keys dynamically shown in a grid layout
  */
-final class DynamicGridKeyboard extends Keyboard {
-    private static final String TAG = DynamicGridKeyboard.class.getSimpleName();
+public class DynamicGridKeyboard extends Keyboard {
+
+    private static final String TAG = "DynamicGridKeyboard";
     private static final int TEMPLATE_KEY_CODE_0 = 0x30;
     private static final int TEMPLATE_KEY_CODE_1 = 0x31;
     private final Object mLock = new Object();
 
-    private final SharedPreferences mPrefs;
     private final int mHorizontalStep;
     private final int mHorizontalGap;
     private final int mVerticalStep;
     private final int mColumnsNum;
-    private final int mMaxKeyCount;
-    private final boolean mIsRecents;
-    private final ArrayDeque<GridKey> mGridKeys = new ArrayDeque<>();
-    private final ArrayDeque<Key> mPendingKeys = new ArrayDeque<>();
+    private final LinkedList<GridKey> mGridKeys = new LinkedList<>();
 
     private List<Key> mCachedGridKeys;
 
-    public DynamicGridKeyboard(final SharedPreferences prefs, final Keyboard templateKeyboard,
-            final int maxKeyCount, final int categoryId) {
+    public DynamicGridKeyboard(final Keyboard templateKeyboard) {
         super(templateKeyboard);
         final Key key0 = getTemplateKey(TEMPLATE_KEY_CODE_0);
         final Key key1 = getTemplateKey(TEMPLATE_KEY_CODE_1);
@@ -64,9 +56,6 @@ final class DynamicGridKeyboard extends Keyboard {
         mHorizontalStep = key0.getWidth() + mHorizontalGap;
         mVerticalStep = key0.getHeight() + mVerticalGap;
         mColumnsNum = mBaseWidth / mHorizontalStep;
-        mMaxKeyCount = maxKeyCount;
-        mIsRecents = categoryId == EmojiCategory.ID_RECENTS;
-        mPrefs = prefs;
     }
 
     private Key getTemplateKey(final int code) {
@@ -87,124 +76,56 @@ final class DynamicGridKeyboard extends Keyboard {
         return mColumnsNum;
     }
 
-    public void addPendingKey(final Key usedKey) {
-        synchronized (mLock) {
-            mPendingKeys.addLast(usedKey);
+    public int getKeyCount() {
+        return mGridKeys.size();
+    }
+
+    public void addKeyFrom(final Key baseKey) {
+        if (baseKey == null) {
+            return;
         }
+        addKey(makeGridKey(baseKey));
     }
 
-    public void flushPendingRecentKeys() {
-        synchronized (mLock) {
-            while (!mPendingKeys.isEmpty()) {
-                addKey(mPendingKeys.pollFirst(), true);
-            }
-            saveRecentKeys();
-        }
-    }
-
-    public void addKeyFirst(final Key usedKey) {
-        addKey(usedKey, true);
-        if (mIsRecents) {
-            saveRecentKeys();
-        }
-    }
-
-    public void addKeyLast(final Key usedKey) {
-        addKey(usedKey, false);
-    }
-
-    private void addKey(final Key usedKey, final boolean addFirst) {
-        if (usedKey == null) {
+    public void addKey(final GridKey key) {
+        if (key == null) {
             return;
         }
         synchronized (mLock) {
             mCachedGridKeys = null;
-            // When a key is added to recents keyboard, we don't want to keep its more keys
-            // neither its hint label. Also, we make sure its background type is matching our keyboard
-            // if key comes from another keyboard (ie. a {@link MoreKeysKeyboard}).
-            final boolean dropMoreKeys = mIsRecents;
-            // Check if hint was a more emoji indicator and prevent its copy if more keys aren't copied
-            final boolean dropHintLabel = dropMoreKeys && "\u25E5".equals(usedKey.getHintLabel());
-            final GridKey key = new GridKey(usedKey,
-                    dropMoreKeys ? null : usedKey.getMoreKeys(),
-                    dropHintLabel ? null : usedKey.getHintLabel(),
-                    mIsRecents ? Key.BACKGROUND_TYPE_EMPTY : usedKey.getBackgroundType());
             while (mGridKeys.remove(key)) {
                 // Remove duplicate keys.
             }
-            if (addFirst) {
-                mGridKeys.addFirst(key);
-            } else {
-                mGridKeys.addLast(key);
-            }
-            while (mGridKeys.size() > mMaxKeyCount) {
-                mGridKeys.removeLast();
-            }
-            int index = 0;
-            for (final GridKey gridKey : mGridKeys) {
-                final int keyX0 = getKeyX0(index);
-                final int keyY0 = getKeyY0(index);
-                final int keyX1 = getKeyX1(index);
-                final int keyY1 = getKeyY1(index);
-                gridKey.updateCoordinates(keyX0, keyY0, keyX1, keyY1);
-                index++;
-            }
+            mGridKeys.add(key);
         }
+        updateKeysCoordinates();
     }
 
-    private void saveRecentKeys() {
-        final ArrayList<Object> keys = new ArrayList<>();
-        for (final Key key : mGridKeys) {
-            if (key.getOutputText() != null) {
-                keys.add(key.getOutputText());
-            } else {
-                keys.add(key.getCode());
-            }
-        }
-        final String jsonStr = JsonUtils.listToJsonStr(keys);
-        Settings.writeEmojiRecentKeys(mPrefs, jsonStr);
+    public void removeLastKey() {
+        mGridKeys.removeLast();
     }
 
-    private static Key getKeyByCode(final Collection<DynamicGridKeyboard> keyboards,
-            final int code) {
-        for (final DynamicGridKeyboard keyboard : keyboards) {
-            for (final Key key : keyboard.getSortedKeys()) {
-                if (key.getCode() == code) {
-                    return key;
-                }
-            }
-        }
-        return null;
+    public void sortKeys(Comparator<GridKey> comparator) {
+        Collections.sort(mGridKeys, comparator);
+        updateKeysCoordinates();
     }
 
-    private static Key getKeyByOutputText(final Collection<DynamicGridKeyboard> keyboards,
-            final String outputText) {
-        for (final DynamicGridKeyboard keyboard : keyboards) {
-            for (final Key key : keyboard.getSortedKeys()) {
-                if (outputText.equals(key.getOutputText())) {
-                    return key;
-                }
-            }
-        }
-        return null;
+    protected GridKey makeGridKey(Key baseKey) {
+        return new GridKey(baseKey,
+                baseKey.getMoreKeys(),
+                baseKey.getHintLabel(),
+                baseKey.getBackgroundType());
     }
 
-    public void loadRecentKeys(final Collection<DynamicGridKeyboard> keyboards) {
-        final String str = Settings.readEmojiRecentKeys(mPrefs);
-        final List<Object> keys = JsonUtils.jsonStrToList(str);
-        for (final Object o : keys) {
-            final Key key;
-            if (o instanceof Integer) {
-                final int code = (Integer)o;
-                key = getKeyByCode(keyboards, code);
-            } else if (o instanceof String) {
-                final String outputText = (String)o;
-                key = getKeyByOutputText(keyboards, outputText);
-            } else {
-                Log.w(TAG, "Invalid object: " + o);
-                continue;
-            }
-            addKeyLast(key);
+    private void updateKeysCoordinates() {
+        int index = 0;
+        for (final GridKey gridKey : mGridKeys) {
+            final int keyX0 = getKeyX0(index);
+            final int keyY0 = getKeyY0(index);
+            final int keyX1 = getKeyX1(index);
+            final int keyY1 = getKeyY1(index);
+            gridKey.updateCoordinates(keyX0, keyY0, keyX1, keyY1);
+            index++;
         }
     }
 
@@ -234,7 +155,7 @@ final class DynamicGridKeyboard extends Keyboard {
             if (mCachedGridKeys != null) {
                 return mCachedGridKeys;
             }
-            final ArrayList<Key> cachedKeys = new ArrayList<Key>(mGridKeys);
+            final ArrayList<Key> cachedKeys = new ArrayList<>(mGridKeys);
             mCachedGridKeys = Collections.unmodifiableList(cachedKeys);
             return mCachedGridKeys;
         }
@@ -246,7 +167,7 @@ final class DynamicGridKeyboard extends Keyboard {
         return getSortedKeys();
     }
 
-    static final class GridKey extends Key {
+    protected static class GridKey extends Key {
         private int mCurrentX;
         private int mCurrentY;
 
@@ -278,6 +199,11 @@ final class DynamicGridKeyboard extends Keyboard {
             if (getCode() != key.getCode()) return false;
             if (!TextUtils.equals(getLabel(), key.getLabel())) return false;
             return TextUtils.equals(getOutputText(), key.getOutputText());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getCode(), getLabel(), getOutputText());
         }
 
         @Override

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/RecentEmoji.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/RecentEmoji.kt
@@ -1,0 +1,78 @@
+package org.dslul.openboard.inputmethod.keyboard.emoji
+
+import org.dslul.openboard.inputmethod.keyboard.Key
+import org.dslul.openboard.inputmethod.latin.common.Constants
+import kotlin.math.log10
+
+class RecentEmoji(
+        val code: Int = Constants.NOT_A_CODE,
+        val text: String? = null,
+        private var uses: LongArray = LongArray(0)
+        ) : Comparable<RecentEmoji> {
+
+    constructor(key: Key) : this(key.code, key.outputText)
+
+    private var frequency = BASE_FREQUENCY
+
+    val lastUse: Long
+        get() = uses.lastOrNull() ?: 0
+
+    val usesToStore: List<Long>
+        get() {
+            return if (uses.size > MIN_COUNT_FOR_NEGLIGIBLE_USES_REMOVAL) {
+                val now = now()
+                val usesWithMagnitudes = uses.associateWith { orderOfMagnitude(now, it) }
+                val magnitudeThreshold = usesWithMagnitudes.maxOf { it.value } + MAGNITUDE_RELATIVE_THRESHOLD_FOR_REMOVAL
+                usesWithMagnitudes.filterValues { it > magnitudeThreshold }.keys.toList()
+            } else {
+                uses.toList()
+            }
+        }
+
+    fun addUseNow() {
+        uses += now()
+    }
+
+    fun setSingleUseNow() {
+        uses = longArrayOf(now())
+    }
+
+    fun setSingleUseFromLastUse() {
+        if (uses.size > 1) {
+            uses = longArrayOf(lastUse)
+        }
+    }
+
+    fun updateFrequency() {
+        val now = now()
+        frequency = uses.fold(BASE_FREQUENCY) { acc, it -> acc * computeUnitFrequency(now, it) }
+    }
+
+    override fun compareTo(other: RecentEmoji): Int {
+        return other.frequency.compareTo(frequency)
+    }
+
+    fun copy() = RecentEmoji(code, text).also { it.uses = uses.copyOf(uses.size) }
+
+    companion object {
+
+        private const val BASE_FREQUENCY = 1f
+        private const val BASE_USE_TIME = 24 * 3600 * 1000L // 12 hours in ms
+        private const val MIN_COUNT_FOR_NEGLIGIBLE_USES_REMOVAL = 32
+        private const val MAGNITUDE_RELATIVE_THRESHOLD_FOR_REMOVAL = -3
+
+        fun now() = System.currentTimeMillis()
+
+        // Ranges in [2.0; 1.0[ with 1.125 for BASE_USE_TIME
+        private fun computeUnitFrequency(now: Long, use: Long): Float {
+            val x = ((now - use) / BASE_USE_TIME.toFloat()).coerceAtLeast(0f)
+            // f(x)=1+(1/(x+1))**2
+            val inv = 1f / (x + 1)
+            return 1f + inv * inv
+        }
+
+        private fun orderOfMagnitude(now: Long, use: Long): Int {
+            return log10(computeUnitFrequency(now, use) - 1).toInt()
+        }
+    }
+}

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/RecentEmojiDbHelper.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/RecentEmojiDbHelper.kt
@@ -1,0 +1,168 @@
+package org.dslul.openboard.inputmethod.keyboard.emoji
+
+import android.content.ContentValues
+import android.content.Context
+import android.database.Cursor
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteOpenHelper
+import android.util.Log
+import android.util.SparseArray
+import androidx.annotation.WorkerThread
+
+/**
+ * Class to deal with recent emojis database
+ */
+class RecentEmojiDbHelper(context: Context) : SQLiteOpenHelper(
+        context,
+        RECENT_EMOJI_DATABASE_NAME,
+        null,
+        RECENT_EMOJI_DATABASE_VERSION
+) {
+
+    override fun onCreate(db: SQLiteDatabase) {
+        db.execSQL(LOG_TABLE_CREATE)
+    }
+
+    override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
+        // Remove all data.
+        db.execSQL("DROP TABLE IF EXISTS $RECENT_EMOJI_TABLE_NAME")
+        onCreate(db)
+    }
+
+    @WorkerThread
+    fun getRecentEmojis(): SparseArray<RecentEmoji> {
+        return SparseArray<RecentEmoji>().apply {
+            readAll(readableDatabase).use { cursor ->
+                while (cursor.moveToNext()) {
+                    val hash = cursor.getInt(cursor.getColumnIndexOrThrow(COLUMN_HASH))
+                    val code = cursor.getInt(cursor.getColumnIndexOrThrow(COLUMN_CODE))
+                    val text = cursor.getString(cursor.getColumnIndexOrThrow(COLUMN_TEXT))
+                    val rawUses = cursor.getString(cursor.getColumnIndexOrThrow(COLUMN_USES))
+                    put(hash, RecentEmoji(code, text, decodeUses(rawUses)))
+                }
+            }
+        }
+    }
+
+    @WorkerThread
+    fun addRecentEmoji(hash: Int, recentEmoji: RecentEmoji) {
+        val result = insert(writableDatabase, hash, recentEmoji.code, recentEmoji.text, recentEmoji.usesToStore)
+        if (result == INVALID_ID) {
+            throw IllegalStateException("Trying to add a recent emoji that " +
+                    "is already in database for hash=$hash")
+        }
+    }
+
+    @WorkerThread
+    fun updateRecentEmojiUses(hash: Int, uses: List<Long>) {
+        val affectedRows = updateUses(writableDatabase, hash, uses)
+        if (affectedRows == 0) {
+            throw IllegalStateException("Trying to update a recent emoji that " +
+                    "is not yet in database for hash=$hash")
+        } else if (affectedRows > 1) {
+            Log.w(TAG, "Updating recent emoji for hash=$hash led in " +
+                    "$affectedRows rows modified.")
+        }
+    }
+
+    @WorkerThread
+    fun removeRecentEmoji(hash: Int) {
+        val affectedRows = delete(writableDatabase, hash)
+        if (affectedRows == 0) {
+            throw IllegalStateException("Trying to remove a recent emoji that " +
+                    "is not yet in database for hash=$hash")
+        } else if (affectedRows > 1) {
+            Log.w(TAG, "Removing recent emoji for hash=$hash led in " +
+                    "$affectedRows rows deleted.")
+        }
+    }
+
+    companion object {
+
+        private const val TAG = "RecentEmojiDbHelper"
+
+        private const val RECENT_EMOJI_DATABASE_NAME = "recentEmoji"
+        private const val RECENT_EMOJI_DATABASE_VERSION = 1
+        private const val RECENT_EMOJI_TABLE_NAME = "recentEmoji"
+        private const val COLUMN_COUNT = 4
+        private const val COLUMN_HASH = "hash"
+        private const val COLUMN_CODE = "code"
+        private const val COLUMN_TEXT = "text"
+        private const val COLUMN_USES = "uses"
+
+        private const val USES_SEPARATOR = ';'
+        private const val EMPTY_STRING = ""
+        private const val INVALID_ID = -1L
+
+        private const val LOG_TABLE_CREATE = ("CREATE TABLE " + RECENT_EMOJI_TABLE_NAME + " ("
+                + COLUMN_HASH + " INTEGER,"
+                + COLUMN_CODE + " INTEGER,"
+                + COLUMN_TEXT + " TEXT,"
+                + COLUMN_USES + " TEXT,"
+                + "PRIMARY KEY (" + COLUMN_HASH + "));")
+
+        fun readAll(db: SQLiteDatabase): Cursor {
+            return db.query(RECENT_EMOJI_TABLE_NAME,
+                    arrayOf(COLUMN_HASH, COLUMN_CODE, COLUMN_TEXT, COLUMN_USES),
+                    null,
+                    null,
+                    null,
+                    null,
+                    null)
+        }
+
+        fun insert(db: SQLiteDatabase, hash: Int, code: Int, text: String?, uses: List<Long>): Long {
+            val contentValues = ContentValues(COLUMN_COUNT).apply {
+                put(COLUMN_HASH, hash)
+                put(COLUMN_CODE, code)
+                if (text != null) put(COLUMN_TEXT, text) else putNull(COLUMN_TEXT)
+                put(COLUMN_USES, encodeUses(uses))
+            }
+            return db.insert(RECENT_EMOJI_TABLE_NAME, null, contentValues)
+        }
+
+        fun delete(db: SQLiteDatabase, hash: Int): Int {
+            return db.delete(RECENT_EMOJI_TABLE_NAME,
+                    "$COLUMN_HASH=?",
+                    arrayOf(hash.toString()))
+        }
+
+        fun updateUses(db: SQLiteDatabase, hash: Int, uses: List<Long>): Int {
+            val contentValues = ContentValues(1).apply {
+                put(COLUMN_USES, encodeUses(uses))
+            }
+            return db.update(RECENT_EMOJI_TABLE_NAME,
+                    contentValues,
+                    "$COLUMN_HASH=?",
+                    arrayOf(hash.toString()))
+        }
+
+        private fun encodeUses(uses: List<Long>): String {
+            if (uses.isEmpty()) return EMPTY_STRING
+            if (uses.size == 1) return uses.first().toString()
+            val builder = StringBuilder()
+            val base = uses.first()
+            builder.append(base)
+            uses.drop(1).forEach { use ->
+                builder.append(USES_SEPARATOR)
+                builder.append(use - base)
+            }
+            return builder.toString()
+        }
+
+        private fun decodeUses(rawString: String): LongArray {
+            val count = rawString.count { it == USES_SEPARATOR } + 1
+            val uses = LongArray(count)
+            var base = 0L
+            rawString.split(USES_SEPARATOR).forEachIndexed { index, part ->
+                if (index == 0) {
+                    base = part.toLong()
+                    uses[0] = base
+                } else {
+                    uses[index] = base + part.toLong()
+                }
+            }
+            return uses
+        }
+    }
+}

--- a/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/RecentEmojiKeyboard.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/keyboard/emoji/RecentEmojiKeyboard.kt
@@ -1,0 +1,207 @@
+package org.dslul.openboard.inputmethod.keyboard.emoji
+
+import android.util.Log
+import android.util.SparseArray
+import androidx.core.util.containsKey
+import androidx.core.util.forEach
+import androidx.core.util.valueIterator
+import org.dslul.openboard.inputmethod.keyboard.Key
+import org.dslul.openboard.inputmethod.keyboard.Keyboard
+import org.dslul.openboard.inputmethod.latin.LatinIME
+import org.dslul.openboard.inputmethod.latin.settings.Settings
+import org.dslul.openboard.inputmethod.latin.utils.ExecutorUtils
+import org.dslul.openboard.inputmethod.latin.utils.getOrPut
+import java.util.*
+
+class RecentEmojiKeyboard(
+        private val recentEmojiDbHelper: RecentEmojiDbHelper,
+        templateKeyboard: Keyboard?,
+        private var emojiBaseKeyboards: Collection<DynamicGridKeyboard>,
+        private val maxKeyCount: Int
+) : DynamicGridKeyboard(templateKeyboard) {
+
+    var listener: OnRecentEmojiChangedListener? = null
+
+    private val recentEmojis = SparseArray<RecentEmoji>()
+    private val pendingKeys = ArrayDeque<Key>()
+    private var hasLoadedRecentEmojis = false
+    private var emojiUsageSaveEnabled = false
+
+    private val gridKeyComparator by lazy {
+        Comparator<GridKey> { key1, key2 ->
+            val e1 = recentEmojis[key1.hashCode()]
+            val e2 = recentEmojis[key2.hashCode()]
+            // Null cases should never append in theory, but we do not want to crash the
+            // whole IME if we have a desync between keyboard data and our recent emojis
+            when {
+                e1 == null && e2 != null -> -1
+                e1 != null && e2 == null -> +1
+                e1 == null && e2 == null -> 0
+                else -> e1.compareTo(e2)
+            }
+        }
+    }
+
+    fun loadRecentEmojis(handler: LatinIME.UIHandler) = startLoadRecentEmojis(handler)
+
+    fun onRecentEmojisAvailable(array: SparseArray<RecentEmoji>) {
+        for (i in array.size() - 1 downTo 0) {
+            val recentEmoji = array.valueAt(i)
+            val key = if (recentEmoji.text != null) getBaseKeyByOutputText(recentEmoji.text)
+            else getBaseKeyByCode(recentEmoji.code)
+            if (key != null) {
+                recentEmojis.put(array.keyAt(i), recentEmoji)
+                addKeyFrom(key)
+                recentEmoji.updateFrequency()
+            } else {
+                Log.i(TAG, "No base key found for: code=${recentEmoji.code} text=${recentEmoji.text}")
+                startRemoveRecentEmoji(array.keyAt(i))
+            }
+        }
+        sortKeys(gridKeyComparator)
+        hasLoadedRecentEmojis = true
+        listener?.onRecentEmojiChanged()
+    }
+
+    fun notifyEmojiUsed(baseKey: Key) {
+        if (!hasLoadedRecentEmojis || Settings.getInstance().current.mIncognitoModeEnabled) {
+            // We do not want to log recent keys while being in incognito or waiting for our initial setup
+            return
+        }
+        val exists = updateRecentEmojiFromKey(baseKey)
+        if (!exists) {
+            addKeyFrom(baseKey)
+        }
+        sortKeys(gridKeyComparator)
+        listener?.onRecentEmojiChanged()
+    }
+
+    fun notifyEmojiUsedPending(baseKey: Key) {
+        if (!hasLoadedRecentEmojis || Settings.getInstance().current.mIncognitoModeEnabled) {
+            // We do not want to log recent keys while being in incognito or waiting for our initial setup
+            return
+        }
+        updateRecentEmojiFromKey(baseKey)
+        pendingKeys.add(baseKey)
+    }
+
+    fun applyPendingChanges() {
+        if (pendingKeys.isEmpty()) {
+            return
+        }
+        while (pendingKeys.isNotEmpty()) {
+            addKeyFrom(pendingKeys.remove())
+        }
+        sortKeys(gridKeyComparator)
+        listener?.onRecentEmojiChanged()
+    }
+
+    private fun updateRecentEmojiFromKey(baseKey: Key): Boolean {
+        checkEmojiUsageSaveEnabled()
+        val hash = Objects.hash(baseKey.code, baseKey.label, baseKey.outputText)
+        val exists = recentEmojis.containsKey(hash)
+        val recentEmoji = recentEmojis.getOrPut(hash) {
+            RecentEmoji(baseKey).also { startAddNewEmoji(hash, it) }
+        }
+        if (emojiUsageSaveEnabled) {
+            recentEmoji.addUseNow()
+        } else {
+            recentEmoji.setSingleUseNow()
+        }
+        startUpdateEmojisUses(hash, recentEmoji)
+
+        // Update frequency of every emoji to keep them comparable
+        recentEmojis.forEach { _, item -> item.updateFrequency() }
+        return exists
+    }
+
+    private fun getBaseKeyByCode(code: Int) = emojiBaseKeyboards.firstNotNullOfOrNull {
+        it.sortedKeys.firstOrNull { key -> key.code == code }
+    }
+
+    private fun getBaseKeyByOutputText(outputText: String) = emojiBaseKeyboards.firstNotNullOfOrNull {
+        it.sortedKeys.firstOrNull { key -> key.outputText == outputText }
+    }
+
+    private fun checkEmojiUsageSaveEnabled() {
+        val oldValue = emojiUsageSaveEnabled
+        val newValue = Settings.getInstance().current.mEmojiUsageFreqEnabled
+        if (oldValue != newValue) {
+            emojiUsageSaveEnabled = newValue
+            if (!newValue) {
+                // Setting is now off, we must forget dynamically usage histories to compute the new simple order.
+                recentEmojis.forEach { hash, recentEmoji ->
+                    recentEmoji.setSingleUseFromLastUse()
+                    startUpdateEmojisUses(hash, recentEmoji)
+                }
+            }
+        }
+    }
+
+    override fun addKeyFrom(usedKey: Key?) {
+        super.addKeyFrom(usedKey)
+        if (keyCount > maxKeyCount) {
+            sortKeys(gridKeyComparator)
+            while (keyCount > maxKeyCount) {
+                removeLastKey()
+                // Find recent emoji with the smallest frequency, corresponding to
+                // the last key we juste removed.
+                val recentEmoji = recentEmojis.valueIterator().asSequence().sorted().last()
+                val index = recentEmojis.indexOfValue(recentEmoji)
+                recentEmojis.removeAt(index)
+                val hash = recentEmojis.keyAt(index)
+                startRemoveRecentEmoji(hash)
+            }
+        }
+    }
+
+    override fun makeGridKey(baseKey: Key): GridKey {
+        // When a key is added to recents keyboard, we don't want to keep its more keys
+        // neither its hint label. Also, we make sure its background type is matching our keyboard
+        // if key comes from another keyboard (ie. a {@link MoreKeysKeyboard}).
+        val dropMoreKeys = true
+        // Check if hint was a more emoji indicator and prevent its copy if more keys aren't copied
+        val dropHintLabel = dropMoreKeys && "\u25E5" == baseKey.hintLabel
+        return GridKey(baseKey,
+                if (dropMoreKeys) null else baseKey.moreKeys,
+                if (dropHintLabel) null else baseKey.hintLabel,
+                Key.BACKGROUND_TYPE_EMPTY)
+    }
+
+    private fun startLoadRecentEmojis(handler: LatinIME.UIHandler) {
+        ExecutorUtils.getBackgroundExecutor(ExecutorUtils.EMOJIS).execute {
+            val result = recentEmojiDbHelper.getRecentEmojis()
+            handler.postUpdateRecentEmojis(result)
+        }
+    }
+
+    private fun startAddNewEmoji(hash: Int, recentEmoji: RecentEmoji) {
+        Settings.getInstance().writeEmojiRecentCount(recentEmojis.size())
+        val localCopy = recentEmoji.copy()
+        ExecutorUtils.getBackgroundExecutor(ExecutorUtils.EMOJIS).execute {
+            recentEmojiDbHelper.addRecentEmoji(hash, localCopy)
+        }
+    }
+
+    private fun startUpdateEmojisUses(hash: Int, recentEmoji: RecentEmoji) {
+        val localList = recentEmoji.usesToStore
+        ExecutorUtils.getBackgroundExecutor(ExecutorUtils.EMOJIS).execute {
+            recentEmojiDbHelper.updateRecentEmojiUses(hash, localList)
+        }
+    }
+
+    private fun startRemoveRecentEmoji(hash: Int) {
+        Settings.getInstance().writeEmojiRecentCount(recentEmojis.size())
+        ExecutorUtils.getBackgroundExecutor(ExecutorUtils.EMOJIS).execute {
+            recentEmojiDbHelper.removeRecentEmoji(hash)
+        }
+    }
+
+    interface OnRecentEmojiChangedListener {
+        fun onRecentEmojiChanged()
+    }
+
+    companion object {
+        private const val TAG = "RecentEmojiKeyboard"
+    }
+}

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/LatinIME.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/LatinIME.java
@@ -47,7 +47,7 @@ import android.view.WindowManager;
 import android.view.inputmethod.CompletionInfo;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodSubtype;
-
+import androidx.annotation.NonNull;
 import org.dslul.openboard.inputmethod.accessibility.AccessibilityUtils;
 import org.dslul.openboard.inputmethod.annotations.UsedForTesting;
 import org.dslul.openboard.inputmethod.compat.EditorInfoCompatUtils;
@@ -63,6 +63,8 @@ import org.dslul.openboard.inputmethod.keyboard.KeyboardActionListener;
 import org.dslul.openboard.inputmethod.keyboard.KeyboardId;
 import org.dslul.openboard.inputmethod.keyboard.KeyboardSwitcher;
 import org.dslul.openboard.inputmethod.keyboard.MainKeyboardView;
+import org.dslul.openboard.inputmethod.keyboard.emoji.EmojiPalettesView;
+import org.dslul.openboard.inputmethod.keyboard.emoji.RecentEmoji;
 import org.dslul.openboard.inputmethod.latin.Suggest.OnGetSuggestedWordsCallback;
 import org.dslul.openboard.inputmethod.latin.SuggestedWords.SuggestedWordInfo;
 import org.dslul.openboard.inputmethod.latin.common.Constants;
@@ -90,14 +92,13 @@ import org.dslul.openboard.inputmethod.latin.utils.StatsUtilsManager;
 import org.dslul.openboard.inputmethod.latin.utils.SubtypeLocaleUtils;
 import org.dslul.openboard.inputmethod.latin.utils.ViewLayoutUtils;
 
+import javax.annotation.Nonnull;
 import java.io.FileDescriptor;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
-
-import javax.annotation.Nonnull;
 
 import static org.dslul.openboard.inputmethod.latin.common.Constants.ImeOption.FORCE_ASCII;
 import static org.dslul.openboard.inputmethod.latin.common.Constants.ImeOption.NO_MICROPHONE;
@@ -229,6 +230,7 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
         private static final int MSG_RESUME_SUGGESTIONS_FOR_START_INPUT = 10;
         private static final int MSG_SWITCH_LANGUAGE_AUTOMATICALLY = 11;
         private static final int MSG_UPDATE_CLIPBOARD_PINNED_CLIPS = 12;
+        private static final int MSG_UPDATE_RECENT_EMOJIS = 13;
         // Update this when adding new messages
         private static final int MSG_LAST = MSG_UPDATE_CLIPBOARD_PINNED_CLIPS;
 
@@ -329,8 +331,16 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
                     break;
                 case MSG_UPDATE_CLIPBOARD_PINNED_CLIPS:
                     @SuppressWarnings("unchecked")
-                    List<ClipboardHistoryEntry> entries = (List<ClipboardHistoryEntry>) msg.obj;
+                    final List<ClipboardHistoryEntry> entries = (List<ClipboardHistoryEntry>) msg.obj;
                     latinIme.mClipboardHistoryManager.onPinnedClipsAvailable(entries);
+                    break;
+                case MSG_UPDATE_RECENT_EMOJIS:
+                    EmojiPalettesView emojiPalettesView = latinIme.mInputView.findViewById(R.id.emoji_palettes_view);
+                    if (emojiPalettesView != null) {
+                        @SuppressWarnings("unchecked")
+                        final SparseArray<RecentEmoji> array = (SparseArray<RecentEmoji>) msg.obj;
+                        emojiPalettesView.onRecentEmojisAvailable(array);
+                    }
                     break;
             }
         }
@@ -456,6 +466,10 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
 
         public void postUpdateClipboardPinnedClips(final List<ClipboardHistoryEntry> clips) {
             obtainMessage(MSG_UPDATE_CLIPBOARD_PINNED_CLIPS, clips).sendToTarget();
+        }
+
+        public void postUpdateRecentEmojis(@NonNull final SparseArray<RecentEmoji> array) {
+            obtainMessage(MSG_UPDATE_RECENT_EMOJIS, array).sendToTarget();
         }
 
         // Working variables for the following methods.

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsValues.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsValues.java
@@ -23,22 +23,19 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.util.Log;
 import android.view.inputmethod.EditorInfo;
-
 import org.dslul.openboard.inputmethod.compat.AppWorkaroundsUtils;
 import org.dslul.openboard.inputmethod.latin.InputAttributes;
 import org.dslul.openboard.inputmethod.latin.R;
 import org.dslul.openboard.inputmethod.latin.RichInputMethodManager;
-import org.dslul.openboard.inputmethod.latin.common.StringUtils;
 import org.dslul.openboard.inputmethod.latin.utils.AsyncResultHolder;
 import org.dslul.openboard.inputmethod.latin.utils.ResourceUtils;
 import org.dslul.openboard.inputmethod.latin.utils.ScriptUtils;
 import org.dslul.openboard.inputmethod.latin.utils.TargetPackageInfoGetterTask;
 
-import java.util.Arrays;
-import java.util.Locale;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Locale;
 
 /**
  * When you call the constructor of this class, you may want to change the current system locale by
@@ -93,6 +90,7 @@ public class SettingsValues {
     public final boolean mSlidingKeyInputPreviewEnabled;
     public final int mKeyLongpressTimeout;
     public final boolean mEnableEmojiAltPhysicalKey;
+    public final boolean mEmojiUsageFreqEnabled;
     public final boolean mShowAppIcon;
     public final boolean mIsShowAppIconSettingInPreferences;
     public final boolean mCloudSyncEnabled;
@@ -181,6 +179,7 @@ public class SettingsValues {
         mKeypressSoundVolume = Settings.readKeypressSoundVolume(prefs, res);
         mEnableEmojiAltPhysicalKey = prefs.getBoolean(
                 Settings.PREF_ENABLE_EMOJI_ALT_PHYSICAL_KEY, true);
+        mEmojiUsageFreqEnabled = Settings.readEmojiUsageFrequencyEnabled(prefs);
         mShowAppIcon = Settings.readShowSetupWizardIcon(prefs, context);
         mIsShowAppIconSettingInPreferences = prefs.contains(Settings.PREF_SHOW_SETUP_WIZARD_ICON);
         mAutoCorrectionThreshold = readAutoCorrectionThreshold(res,

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/ExecutorUtils.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/ExecutorUtils.java
@@ -17,7 +17,6 @@
 package org.dslul.openboard.inputmethod.latin.utils;
 
 import android.util.Log;
-
 import org.dslul.openboard.inputmethod.annotations.UsedForTesting;
 
 import java.lang.Thread.UncaughtExceptionHandler;
@@ -35,9 +34,11 @@ public class ExecutorUtils {
 
     public static final String KEYBOARD = "Keyboard";
     public static final String SPELLING = "Spelling";
+    public static final String EMOJIS = "RecentEmojis";
 
     private static ScheduledExecutorService sKeyboardExecutorService = newExecutorService(KEYBOARD);
     private static ScheduledExecutorService sSpellingExecutorService = newExecutorService(SPELLING);
+    private static ScheduledExecutorService sEmojisExecutorService = newExecutorService(EMOJIS);
 
     private static ScheduledExecutorService newExecutorService(final String name) {
         return Executors.newSingleThreadScheduledExecutor(new ExecutorFactory(name));
@@ -89,6 +90,8 @@ public class ExecutorUtils {
                 return sKeyboardExecutorService;
             case SPELLING:
                 return sSpellingExecutorService;
+            case EMOJIS:
+                return sEmojisExecutorService;
             default:
                 throw new IllegalArgumentException("Invalid executor: " + name);
         }
@@ -113,6 +116,8 @@ public class ExecutorUtils {
             case SPELLING:
                 sSpellingExecutorService = newExecutorService(SPELLING);
                 break;
+            case EMOJIS:
+                sEmojisExecutorService = newExecutorService(EMOJIS);
             default:
                 throw new IllegalArgumentException("Invalid executor: " + name);
         }

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/SparseArrayUtils.kt
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/utils/SparseArrayUtils.kt
@@ -1,0 +1,33 @@
+package org.dslul.openboard.inputmethod.latin.utils
+
+import android.util.SparseArray
+import androidx.core.util.forEach
+
+public inline fun <V> SparseArray<V>.filter(predicate: (Int, V) -> Boolean): SparseArray<V> {
+    return filterTo(SparseArray<V>(), predicate)
+}
+
+public inline fun <V, C : SparseArray<in V>> SparseArray<V>.filterTo(destination: C, predicate: (Int, V) -> Boolean): C {
+    forEach { key, value -> if (predicate(key, value)) destination.append(key, value) }
+    return destination
+}
+
+public inline fun <V, R> SparseArray<V>.map(transform: (Int, V) -> R): SparseArray<R> {
+    return mapTo(SparseArray<R>(), transform)
+}
+
+public inline fun <V, R, C : SparseArray<in R>> SparseArray<V>.mapTo(destination: C, transform: (Int, V) -> R): C {
+    forEach { key, value -> destination.put(key, transform(key, value)) }
+    return destination
+}
+
+public inline fun <V> SparseArray<V>.getOrPut(key: Int, defaultValue: () -> V): V {
+    val value = get(key)
+    return if (value == null) {
+        val answer = defaultValue()
+        put(key, answer)
+        answer
+    } else {
+        value
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -178,6 +178,10 @@
     <string name="enable_clipboard_history_summary">If disabled, clipboard key will paste clipboard content if any</string>
     <!-- Preferences item for enabling clipboard history -->
     <string name="clipboard_history_retention_time">History retention time</string>
+    <!-- Preferences item for enabling emoji usage frequency saving -->
+    <string name="emoji_usage_freq">Save emojis usage frequency</string>
+    <!-- Description for enabling/disabling emoji usage frequency saving mentioning that if disabled, last use order is used. -->
+    <string name="emoji_usage_freq_summary">Allows recent emojis to be sorted accordingly to their frequency of use</string>
     <!-- Preferences item for enabling swipe deletion -->
     <string name="delete_swipe">Delete swipe</string>
     <!-- Description for "delete_swipe" option. -->

--- a/app/src/main/res/xml/prefs_screen_advanced.xml
+++ b/app/src/main/res/xml/prefs_screen_advanced.xml
@@ -77,6 +77,12 @@
             android:defaultValue="true" />
 
         <CheckBoxPreference
+            android:key="pref_emoji_usage_freq"
+            android:title="@string/emoji_usage_freq"
+            android:summary="@string/emoji_usage_freq_summary"
+            android:defaultValue="true" />
+
+        <CheckBoxPreference
             android:key="pref_autospace_after_punctuation"
             android:title="@string/autospace_after_punctuation"
             android:summary="@string/autospace_after_punctuation_summary"


### PR DESCRIPTION
### What is it ?
This PR adds - as an optional feature enabled by default - recent emojis sorted accordingly to their frequency of use. As opposite to the "last used" sorting currently in place.

The goal was to allow a sorting method that would take into account number of uses as well as how recent these uses are.
### How it works ?
To explain this briefly, as incoming data we have dates at which emojis had been use, and as outcoming data we want a a value, that we called frequency, that we use to compare emoji against each other.

We compute that "frequency" for each recent emoji by following these steps:
- For each date of use, we compute the time elapsed from now, and divide it by a reference time period (24h, but it can be anything else).
- We then throw this value in a well chosen mathematical function that will give more importance for recent dates (2), and decreasing importance the older the dates get (tanganting 1 but never reaching it).
Here is a graphical representation for 0 to 12 times our reference time (which is 24h):
![image](https://user-images.githubusercontent.com/11336456/171296106-4730e11e-5b1c-4358-aa16-daed7a417ebf.png)
- Because the mathematical function has been so well chosen, it gives values at least equals to 1, so we can multiply all the frequencies together to calculate the total frequency of this emoji.
- We then are able to sort every recent emoji based on previously calculated frequencues. 

The model for now is "as is", and is in test since 1 week, but may need a bit of testing by a larger audience.

Fixes #55