### PR TITLE
Add Auto-correction Confidence settings

### DIFF
--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/CorrectionSettingsFragment.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/CorrectionSettingsFragment.java
@@ -16,7 +16,6 @@
 
 package org.dslul.openboard.inputmethod.latin.settings;
 
-import android.Manifest;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -25,12 +24,8 @@ import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.os.Bundle;
 import android.preference.Preference;
-import android.preference.SwitchPreference;
-import android.text.TextUtils;
 
 import org.dslul.openboard.inputmethod.latin.R;
-import org.dslul.openboard.inputmethod.latin.permissions.PermissionsManager;
-import org.dslul.openboard.inputmethod.latin.permissions.PermissionsUtil;
 import org.dslul.openboard.inputmethod.latin.userdictionary.UserDictionaryList;
 import org.dslul.openboard.inputmethod.latin.userdictionary.UserDictionarySettings;
 
@@ -44,6 +39,7 @@ import java.util.TreeSet;
  * - Add-on dictionaries
  * - Block offensive words
  * - Auto-correction
+ * - Auto-correction confidence
  * - Show correction suggestions
  * - Personalized suggestions
  * - Suggest Contact names
@@ -73,6 +69,18 @@ public final class CorrectionSettingsFragment extends SubScreenFragment
         if (ri == null) {
             overwriteUserDictionaryPreference(editPersonalDictionary);
         }
+
+        refreshEnabledSettings();
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(final SharedPreferences prefs, final String key) {
+        refreshEnabledSettings();
+    }
+
+    private void refreshEnabledSettings() {
+        setPreferenceEnabled(Settings.PREF_AUTO_CORRECTION_CONFIDENCE,
+                Settings.readAutoCorrectEnabled(getSharedPreferences(), getResources()));
     }
 
     private void overwriteUserDictionaryPreference(final Preference userDictionaryPreference) {

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/Settings.java
@@ -65,10 +65,8 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_VOICE_INPUT_KEY = "pref_voice_input_key";
     public static final String PREF_CLIPBOARD_CLIPBOARD_KEY = "pref_clipboard_clipboard_key";
     public static final String PREF_EDIT_PERSONAL_DICTIONARY = "edit_personal_dictionary";
-    // PREF_AUTO_CORRECTION_THRESHOLD_OBSOLETE is obsolete. Use PREF_AUTO_CORRECTION instead.
-    public static final String PREF_AUTO_CORRECTION_THRESHOLD_OBSOLETE =
-            "auto_correction_threshold";
     public static final String PREF_AUTO_CORRECTION = "pref_key_auto_correction";
+    public static final String PREF_AUTO_CORRECTION_CONFIDENCE = "pref_key_auto_correction_confidence";
     // PREF_SHOW_SUGGESTIONS_SETTING_OBSOLETE is obsolete. Use PREF_SHOW_SUGGESTIONS instead.
     public static final String PREF_SHOW_SUGGESTIONS_SETTING_OBSOLETE = "show_suggestions_setting";
     public static final String PREF_SHOW_SUGGESTIONS = "show_suggestions";
@@ -173,7 +171,6 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
         mRes = context.getResources();
         mPrefs = DeviceProtectedUtils.getSharedPreferences(context);
         mPrefs.registerOnSharedPreferenceChangeListener(this);
-        upgradeAutocorrectionSettings(mPrefs, mRes);
     }
 
     public void onDestroy() {
@@ -245,6 +242,12 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static boolean readAutoCorrectEnabled(final SharedPreferences prefs,
                                                  final Resources res) {
         return prefs.getBoolean(PREF_AUTO_CORRECTION, true);
+    }
+
+    public static String readAutoCorrectConfidence(final SharedPreferences prefs,
+                                                   final Resources res) {
+        return prefs.getString(PREF_AUTO_CORRECTION_CONFIDENCE,
+                res.getString(R.string.auto_correction_threshold_mode_index_modest));
     }
 
     public static float readPlausibilityThreshold(final Resources res) {
@@ -512,22 +515,5 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static int readLastShownEmojiCategoryPageId(
             final SharedPreferences prefs, final int defValue) {
         return prefs.getInt(PREF_LAST_SHOWN_EMOJI_CATEGORY_PAGE_ID, defValue);
-    }
-
-    private void upgradeAutocorrectionSettings(final SharedPreferences prefs, final Resources res) {
-        final String thresholdSetting =
-                prefs.getString(PREF_AUTO_CORRECTION_THRESHOLD_OBSOLETE, null);
-        if (thresholdSetting != null) {
-            SharedPreferences.Editor editor = prefs.edit();
-            editor.remove(PREF_AUTO_CORRECTION_THRESHOLD_OBSOLETE);
-            final String autoCorrectionOff =
-                    res.getString(R.string.auto_correction_threshold_mode_index_off);
-            if (thresholdSetting.equals(autoCorrectionOff)) {
-                editor.putBoolean(PREF_AUTO_CORRECTION, false);
-            } else {
-                editor.putBoolean(PREF_AUTO_CORRECTION, true);
-            }
-            editor.commit();
-        }
     }
 }

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsValues.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsValues.java
@@ -53,6 +53,7 @@ public class SettingsValues {
     private static final String FLOAT_NEGATIVE_INFINITY_MARKER_STRING = "floatNegativeInfinity";
     private static final int TIMEOUT_TO_GET_TARGET_PACKAGE = 5; // seconds
     public static final float DEFAULT_SIZE_SCALE = 1.0f; // 100%
+    public static final float AUTO_CORRECTION_DISABLED_THRESHOLD = Float.MAX_VALUE;
 
     // From resources:
     public final SpacingAndPunctuations mSpacingAndPunctuations;
@@ -163,9 +164,9 @@ public class SettingsValues {
                 && inputAttributes.mIsGeneralTextInput;
         mBlockPotentiallyOffensive = Settings.readBlockPotentiallyOffensive(prefs, res);
         mAutoCorrectEnabled = Settings.readAutoCorrectEnabled(prefs, res);
-        final String autoCorrectionThresholdRawValue = mAutoCorrectEnabled
-                ? Settings.readAutoCorrectConfidence(prefs, res)
-                : res.getString(R.string.auto_correction_threshold_mode_index_off);
+        mAutoCorrectionThreshold = mAutoCorrectEnabled
+                ? readAutoCorrectionThreshold(res, prefs)
+                : AUTO_CORRECTION_DISABLED_THRESHOLD;
         mBigramPredictionEnabled = readBigramPredictionEnabled(prefs, res);
         mDoubleSpacePeriodTimeout = res.getInteger(R.integer.config_double_space_period_timeout);
         mHasHardwareKeyboard = Settings.readHasHardwareKeyboard(res.getConfiguration());
@@ -183,8 +184,6 @@ public class SettingsValues {
                 Settings.PREF_ENABLE_EMOJI_ALT_PHYSICAL_KEY, true);
         mShowAppIcon = Settings.readShowSetupWizardIcon(prefs, context);
         mIsShowAppIconSettingInPreferences = prefs.contains(Settings.PREF_SHOW_SETUP_WIZARD_ICON);
-        mAutoCorrectionThreshold = readAutoCorrectionThreshold(res,
-                autoCorrectionThresholdRawValue);
         mPlausibilityThreshold = Settings.readPlausibilityThreshold(res);
         mGestureInputEnabled = Settings.readGestureInputEnabled(prefs, res);
         mGestureTrailEnabled = prefs.getBoolean(Settings.PREF_GESTURE_PREVIEW_TRAIL, true);
@@ -331,7 +330,8 @@ public class SettingsValues {
     }
 
     private static float readAutoCorrectionThreshold(final Resources res,
-                                                     final String currentAutoCorrectionSetting) {
+                                                     final SharedPreferences prefs) {
+        final String currentAutoCorrectionSetting = Settings.readAutoCorrectConfidence(prefs, res);
         final String[] autoCorrectionThresholdValues = res.getStringArray(
                 R.array.auto_correction_threshold_values);
         // When autoCorrectionThreshold is greater than 1.0, it's like auto correction is off.

--- a/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsValues.java
+++ b/app/src/main/java/org/dslul/openboard/inputmethod/latin/settings/SettingsValues.java
@@ -164,7 +164,7 @@ public class SettingsValues {
         mBlockPotentiallyOffensive = Settings.readBlockPotentiallyOffensive(prefs, res);
         mAutoCorrectEnabled = Settings.readAutoCorrectEnabled(prefs, res);
         final String autoCorrectionThresholdRawValue = mAutoCorrectEnabled
-                ? res.getString(R.string.auto_correction_threshold_mode_index_modest)
+                ? Settings.readAutoCorrectConfidence(prefs, res)
                 : res.getString(R.string.auto_correction_threshold_mode_index_off);
         mBigramPredictionEnabled = readBigramPredictionEnabled(prefs, res);
         mDoubleSpacePeriodTimeout = res.getInteger(R.integer.config_double_space_period_timeout);

--- a/app/src/main/res/values/config-auto-correction-thresholds.xml
+++ b/app/src/main/res/values/config-auto-correction-thresholds.xml
@@ -48,14 +48,12 @@
 
     <!-- The array of the auto correction threshold settings values. -->
     <string-array name="auto_correction_threshold_mode_indexes" translatable="false">
-      <item>@string/auto_correction_threshold_mode_index_off</item>
       <item>@string/auto_correction_threshold_mode_index_modest</item>
       <item>@string/auto_correction_threshold_mode_index_aggressive</item>
       <item>@string/auto_correction_threshold_mode_index_very_aggressive</item>
     </string-array>
     <!-- The array of the human readable auto correction threshold settings entries. -->
     <string-array name="auto_correction_threshold_modes" translatable="false">
-      <item>@string/auto_correction_threshold_mode_off</item>
       <item>@string/auto_correction_threshold_mode_modest</item>
       <item>@string/auto_correction_threshold_mode_aggressive</item>
       <item>@string/auto_correction_threshold_mode_very_aggressive</item>

--- a/app/src/main/res/values/config-auto-correction-thresholds.xml
+++ b/app/src/main/res/values/config-auto-correction-thresholds.xml
@@ -21,8 +21,6 @@
 <resources>
     <!-- The array of auto correction threshold values. -->
     <string-array name="auto_correction_threshold_values" translatable="false">
-        <!-- Off, When auto correction setting is Off, this value is not used. -->
-        <item>floatMaxValue</item>
         <!-- Modest : Suggestion whose normalized score is greater than this value
              will be subject to auto-correction. -->
         <item>0.185</item>
@@ -41,10 +39,9 @@
     <string name="plausibility_threshold" translatable="false">0.065</string>
 
     <!-- The index of the auto correction threshold values array. -->
-    <string name="auto_correction_threshold_mode_index_off" translatable="false">0</string>
-    <string name="auto_correction_threshold_mode_index_modest" translatable="false">1</string>
-    <string name="auto_correction_threshold_mode_index_aggressive" translatable="false">2</string>
-    <string name="auto_correction_threshold_mode_index_very_aggressive" translatable="false">3</string>
+    <string name="auto_correction_threshold_mode_index_modest" translatable="false">0</string>
+    <string name="auto_correction_threshold_mode_index_aggressive" translatable="false">1</string>
+    <string name="auto_correction_threshold_mode_index_very_aggressive" translatable="false">2</string>
 
     <!-- The array of the auto correction threshold settings values. -->
     <string-array name="auto_correction_threshold_mode_indexes" translatable="false">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,6 +140,8 @@
     <string name="auto_correction">Auto-correction</string>
     <!-- Description for auto correction [CHAR LIMIT=65 (two lines) or 30 (fits on one line, preferable)] -->
     <string name="auto_correction_summary">Spacebar and punctuation automatically correct mistyped words</string>
+    <!-- Option to change the confidence level of the auto correction [CHAR LIMIT=20] -->
+    <string name="auto_correction_confidence">Auto-correction confidence</string>
     <!-- Option to disable auto correction. [CHAR LIMIT=20] -->
     <string name="auto_correction_threshold_mode_off">Off</string>
     <!-- Option to suggest auto correction suggestions modestly. Auto-corrects only to a word which has small edit distance from typed word. [CHAR LIMIT=20] -->

--- a/app/src/main/res/xml/prefs_screen_correction.xml
+++ b/app/src/main/res/xml/prefs_screen_correction.xml
@@ -41,6 +41,14 @@
             android:defaultValue="true"
             android:persistent="true" />
 
+        <ListPreference
+            android:key="pref_key_auto_correction_confidence"
+            android:title="@string/auto_correction_confidence"
+            android:summary="%s"
+            android:entries="@array/auto_correction_threshold_modes"
+            android:entryValues="@array/auto_correction_threshold_mode_indexes"
+            android:defaultValue="@string/auto_correction_threshold_mode_index_modest" />
+
         <CheckBoxPreference
             android:key="auto_cap"
             android:title="@string/auto_cap"


### PR DESCRIPTION
Hello!

This PR adds an Auto-correction Confidence option, letting the user configure how aggressive OpenBoard is with it's auto-correction of typos.

When using OpenBoard, I noticed that the keyboard was very good at coming up with fixes for my typos, but it didn't always auto-correct them for me. Instead I need to select the correction manually from the suggestions bar. This lead to me needing to slow down my typing, when I would be more than happy for OpenBoard to just insert the correction for me itself.

While looking into the issue, it was noticed that almost all the functionality to achieve what I was looking for was already included within OpenBoard, it just wasn't currently in use. This PR is essentially just wiring up the existing auto-correct aggression levels within the codebase to a new configuration option.

The new auto-correct confidence setting defaults to "modest", which is the existing confidence level in use in OpenBoard.

This would fix #687.

Screenshots:
[New "Auto-correct confidence" setting](https://user-images.githubusercontent.com/49100076/187300081-b4611e81-34fd-4268-b2a8-ca2e7bce60b1.png)
[Available confidence levels](https://user-images.githubusercontent.com/49100076/187300295-b1785a8f-0d21-4e8a-a884-e2b031e20bdc.png)
[Setting is disabled when auto-correct is disabled](https://user-images.githubusercontent.com/49100076/187300364-069495dc-329d-4884-9698-a952cbf407f2.png)

Note: The PR also removes an auto-correction upgrade method, which I _believe_ came from the AOSP keyboard and has never been run on OpenBoard. To me, it would look confusing for this method to still be in the code when this new setting is available, so I removed it.

Thanks!